### PR TITLE
cli: add missing admin output

### DIFF
--- a/pkg/cli/status.go
+++ b/pkg/cli/status.go
@@ -96,6 +96,8 @@ func runNodeStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("ID:", node.ID)
 	fmt.Println("Service:", node.Service)
+	fmt.Println("Locality:", node.Locality)
+	fmt.Println("Created:", node.Created)
 	fmt.Println("Revision:", node.Revision)
 	fmt.Println("Metadata:")
 
@@ -116,17 +118,23 @@ func displayNodes(nodes []*cluster.Node) {
 		return nodes[i].ID < nodes[j].ID
 	})
 
-	tbl := table.New("ID", "Service", "Revision")
+	tbl := table.New("ID", "Service", "Locality", "Created", "Revision")
 	for _, node := range nodes {
-		tbl.AddRow(node.ID, node.Service, formatRevision(node.Revision))
+		tbl.AddRow(
+			node.ID,
+			node.Service,
+			node.Locality,
+			node.Created,
+			formatRevision(node.Revision),
+		)
 	}
 
 	tbl.Print()
 }
 
 func formatRevision(revision string) string {
-	if len(revision) > 7 {
-		return revision[:7] + "..."
+	if len(revision) > 10 {
+		return revision[:10] + "..."
 	}
 	return revision
 }


### PR DESCRIPTION
# Description
Adds all node state to admin CLI
```
% go run cmd/fuddle/main.go status cluster
ID                 Service   Locality     Created        Revision
counter-4eef71da   counter   us-east-1-b  1678871917561  80724cfc1d...
counter-56ddb85a   counter   us-east-1-c  1678871917562  80724cfc1d...
counter-83e9ad15   counter   us-east-1-a  1678871917561  80724cfc1d...
frontend-25b2b5d1  frontend  us-east-1-a  1678871917556  80724cfc1d...
frontend-41225042  frontend  us-east-1-c  1678871917559  80724cfc1d...
frontend-620a3c3d  frontend  us-east-1-b  1678871917557  80724cfc1d...
fuddle-35e88b45    fuddle    us-east-1-a  1678871917555  80724cfc1d...

% go run cmd/fuddle/main.go status node fuddle-35e88b45
ID: fuddle-35e88b45
Service: fuddle
Locality: us-east-1-a
Created: 1678871917555
Revision: 80724cfc1d14cf0512eb95895c8e320818b3b4d3
Metadata:
    addr.admin: 127.0.0.1:8221
    addr.registry: 127.0.0.1:8220
```