### PR TITLE
counter service rebalancing

### DIFF
--- a/demos/counter/pkg/client/counter/client.go
+++ b/demos/counter/pkg/client/counter/client.go
@@ -42,12 +42,12 @@ func NewClient(partitioner Partitioner) *Client {
 
 // Register registers the user for the given ID, which will call onUpdate
 // whenever the count changes. Returns a function to unregister.
-func (c *Client) Register(id string, onUpdate func(c uint64)) (func() error, error) {
+func (c *Client) Register(id string, onUpdate func(c uint64), onError func(e error)) (func() error, error) {
 	counter, err := c.counter(id)
 	if err != nil {
 		return nil, err
 	}
-	return counter.Register(onUpdate)
+	return counter.Register(onUpdate, onError)
 }
 
 func (c *Client) Close() {

--- a/demos/counter/pkg/client/counter/client.go
+++ b/demos/counter/pkg/client/counter/client.go
@@ -16,7 +16,6 @@
 package counter
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -63,13 +62,8 @@ func (c *Client) counter(id string) (*counter, error) {
 
 	counter, ok := c.counters[id]
 	if !ok {
-		addr, ok := c.partitioner.Locate(id)
-		if !ok {
-			return nil, fmt.Errorf("no available backends")
-		}
-
 		var err error
-		counter, err = newCounter(id, addr)
+		counter, err = newCounter(id, c.partitioner)
 		if err != nil {
 			return nil, err
 		}

--- a/demos/counter/pkg/client/counter/murmur3partitioner.go
+++ b/demos/counter/pkg/client/counter/murmur3partitioner.go
@@ -92,6 +92,7 @@ func (p *Murmur3Partitioner) SetNodes(nodes map[string]string) {
 
 	p.nodes = hashedNodes
 
+	// Check any handles whose location has changed.
 	for handle := range p.handles {
 		addr, ok := p.locateLocked(handle.ID)
 		if ok {

--- a/demos/counter/pkg/client/counter/murmur3partitioner.go
+++ b/demos/counter/pkg/client/counter/murmur3partitioner.go
@@ -39,21 +39,21 @@ func NewMurmur3Partitioner() *Murmur3Partitioner {
 	return &Murmur3Partitioner{}
 }
 
-func (p *Murmur3Partitioner) Locate(id string) (string, bool) {
+func (p *Murmur3Partitioner) Locate(id string, onRelocate func(addr string)) (string, func(), bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
 	if len(p.nodes) == 0 {
-		return "", false
+		return "", nil, false
 	}
 
 	hash := murmur3.Sum64([]byte(id))
 	for i := len(p.nodes) - 1; i >= 0; i-- {
 		if p.nodes[i].Hash >= hash {
-			return p.nodes[i].Addr, true
+			return p.nodes[i].Addr, nil, true
 		}
 	}
-	return p.nodes[len(p.nodes)-1].Addr, true
+	return p.nodes[len(p.nodes)-1].Addr, nil, true
 }
 
 func (p *Murmur3Partitioner) SetNodes(nodes map[string]string) {

--- a/demos/counter/pkg/client/counter/murmur3partitioner_test.go
+++ b/demos/counter/pkg/client/counter/murmur3partitioner_test.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package counter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMurmur3Partitioner_Locate(t *testing.T) {
+	p := NewMurmur3Partitioner()
+
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-2": "192.168.1.2",
+		"node-3": "192.168.1.3",
+	})
+
+	// Lookup foo.
+	addr, _, ok := p.Locate("foo", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.2", addr)
+
+	// Remove the node foo was located and verify it has moved.
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-3": "192.168.1.3",
+	})
+	addr, _, ok = p.Locate("foo", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.1", addr)
+
+	// Add the original node back and verify foo moves back to that node.
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-2": "192.168.1.2",
+		"node-3": "192.168.1.3",
+	})
+	addr, _, ok = p.Locate("foo", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.2", addr)
+}
+
+func TestMurmur3Partitioner_LocateWithOnRelocate(t *testing.T) {
+	p := NewMurmur3Partitioner()
+
+	relocates := make(chan string, 1)
+
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-2": "192.168.1.2",
+		"node-3": "192.168.1.3",
+	})
+
+	// Lookup foo.
+	addr, unregister, ok := p.Locate("foo", func(addr string, ok bool) {
+		assert.True(t, ok)
+		relocates <- addr
+	})
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.2", addr)
+	defer unregister()
+
+	// Remove the node foo was located and verify it has moved.
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-3": "192.168.1.3",
+	})
+	select {
+	case addr = <-relocates:
+		assert.Equal(t, "192.168.1.1", addr)
+	case <-time.After(time.Second):
+		t.Error("timeout")
+	}
+
+	// Add the original node back and verify foo moves back to that node.
+	p.SetNodes(map[string]string{
+		"node-1": "192.168.1.1",
+		"node-2": "192.168.1.2",
+		"node-3": "192.168.1.3",
+	})
+	select {
+	case addr = <-relocates:
+		assert.Equal(t, "192.168.1.2", addr)
+	case <-time.After(time.Second):
+		t.Error("timeout")
+	}
+}
+
+func TestMurmur3Partitioner_LocateNoNodes(t *testing.T) {
+	p := NewMurmur3Partitioner()
+	_, _, ok := p.Locate("foo", nil)
+	assert.False(t, ok)
+}

--- a/demos/counter/pkg/client/counter/murmur3partitioner_test.go
+++ b/demos/counter/pkg/client/counter/murmur3partitioner_test.go
@@ -34,7 +34,7 @@ func TestMurmur3Partitioner_Locate(t *testing.T) {
 	// Lookup foo.
 	addr, _, ok := p.Locate("foo", nil)
 	assert.True(t, ok)
-	assert.Equal(t, "192.168.1.2", addr)
+	assert.Equal(t, NodeAddr{"node-2", "192.168.1.2"}, addr)
 
 	// Remove the node foo was located and verify it has moved.
 	p.SetNodes(map[string]string{
@@ -43,7 +43,7 @@ func TestMurmur3Partitioner_Locate(t *testing.T) {
 	})
 	addr, _, ok = p.Locate("foo", nil)
 	assert.True(t, ok)
-	assert.Equal(t, "192.168.1.1", addr)
+	assert.Equal(t, NodeAddr{"node-3", "192.168.1.3"}, addr)
 
 	// Add the original node back and verify foo moves back to that node.
 	p.SetNodes(map[string]string{
@@ -53,13 +53,13 @@ func TestMurmur3Partitioner_Locate(t *testing.T) {
 	})
 	addr, _, ok = p.Locate("foo", nil)
 	assert.True(t, ok)
-	assert.Equal(t, "192.168.1.2", addr)
+	assert.Equal(t, NodeAddr{"node-2", "192.168.1.2"}, addr)
 }
 
 func TestMurmur3Partitioner_LocateWithOnRelocate(t *testing.T) {
 	p := NewMurmur3Partitioner()
 
-	relocates := make(chan string, 1)
+	relocates := make(chan NodeAddr, 1)
 
 	p.SetNodes(map[string]string{
 		"node-1": "192.168.1.1",
@@ -68,12 +68,12 @@ func TestMurmur3Partitioner_LocateWithOnRelocate(t *testing.T) {
 	})
 
 	// Lookup foo.
-	addr, unregister, ok := p.Locate("foo", func(addr string, ok bool) {
+	addr, unregister, ok := p.Locate("foo", func(addr NodeAddr, ok bool) {
 		assert.True(t, ok)
 		relocates <- addr
 	})
 	assert.True(t, ok)
-	assert.Equal(t, "192.168.1.2", addr)
+	assert.Equal(t, NodeAddr{"node-2", "192.168.1.2"}, addr)
 	defer unregister()
 
 	// Remove the node foo was located and verify it has moved.
@@ -83,7 +83,7 @@ func TestMurmur3Partitioner_LocateWithOnRelocate(t *testing.T) {
 	})
 	select {
 	case addr = <-relocates:
-		assert.Equal(t, "192.168.1.1", addr)
+		assert.Equal(t, NodeAddr{"node-3", "192.168.1.3"}, addr)
 	case <-time.After(time.Second):
 		t.Error("timeout")
 	}
@@ -96,7 +96,7 @@ func TestMurmur3Partitioner_LocateWithOnRelocate(t *testing.T) {
 	})
 	select {
 	case addr = <-relocates:
-		assert.Equal(t, "192.168.1.2", addr)
+		assert.Equal(t, NodeAddr{"node-2", "192.168.1.2"}, addr)
 	case <-time.After(time.Second):
 		t.Error("timeout")
 	}

--- a/demos/counter/pkg/client/counter/partitioner.go
+++ b/demos/counter/pkg/client/counter/partitioner.go
@@ -15,7 +15,12 @@
 
 package counter
 
+type NodeAddr struct {
+	ID   string
+	Addr string
+}
+
 type Partitioner interface {
-	Locate(id string, onRelocate func(addr string, ok bool)) (string, func(), bool)
+	Locate(id string, onRelocate func(addr NodeAddr, ok bool)) (NodeAddr, func(), bool)
 	SetNodes(nodes map[string]string)
 }

--- a/demos/counter/pkg/client/counter/partitioner.go
+++ b/demos/counter/pkg/client/counter/partitioner.go
@@ -16,6 +16,6 @@
 package counter
 
 type Partitioner interface {
-	Locate(id string, onRelocate func(addr string)) (string, func(), bool)
+	Locate(id string, onRelocate func(addr string, ok bool)) (string, func(), bool)
 	SetNodes(nodes map[string]string)
 }

--- a/demos/counter/pkg/client/counter/partitioner.go
+++ b/demos/counter/pkg/client/counter/partitioner.go
@@ -16,6 +16,6 @@
 package counter
 
 type Partitioner interface {
-	Locate(id string) (string, bool)
+	Locate(id string, onRelocate func(addr string)) (string, func(), bool)
 	SetNodes(nodes map[string]string)
 }

--- a/demos/counter/pkg/service/counter/counter_integration_test.go
+++ b/demos/counter/pkg/service/counter/counter_integration_test.go
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package counter
+//go:build integration
+
+package counter_test
 
 import (
 	"testing"
@@ -27,7 +29,7 @@ import (
 
 // Tests registering increments the count and receives update when the
 // count changes.
-func TestCounter_Register(t *testing.T) {
+func TestService_Register(t *testing.T) {
 	c, err := cluster.NewCluster(
 		cluster.WithFuddleNodes(1),
 		cluster.WithCounterNodes(3),

--- a/demos/counter/pkg/service/counter/grpc.go
+++ b/demos/counter/pkg/service/counter/grpc.go
@@ -71,6 +71,11 @@ func (s *grpcServer) GracefulStop() {
 	s.server.GracefulStop()
 }
 
+func (s *grpcServer) Stop() {
+	s.logger.Info("starting grpc server hard shutdown")
+	s.server.Stop()
+}
+
 // grpcServer returns the underlying GRPC server. Used to register handlers.
 func (s *grpcServer) GRPCServer() *grpc.Server {
 	return s.server

--- a/demos/counter/pkg/service/counter/service.go
+++ b/demos/counter/pkg/service/counter/service.go
@@ -96,3 +96,14 @@ func (s *Service) GracefulStop() {
 
 	s.grpcServer.GracefulStop()
 }
+
+func (s *Service) Stop() {
+	s.logger.Info("starting node hard shutdown")
+
+	// Unregister the node from the cluster before shutting down the server.
+	if err := s.registry.Unregister(); err != nil {
+		s.logger.Error("failed to unregister", zap.Error(err))
+	}
+
+	s.grpcServer.Stop()
+}

--- a/demos/counter/pkg/service/frontend/frontend_integration_test.go
+++ b/demos/counter/pkg/service/frontend/frontend_integration_test.go
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package counter
+//go:build integration
+
+package frontend_test
 
 import (
 	"fmt"

--- a/demos/counter/pkg/service/frontend/server.go
+++ b/demos/counter/pkg/service/frontend/server.go
@@ -90,6 +90,10 @@ func (s *server) GracefulStop() {
 	}
 }
 
+func (s *server) Stop() {
+	s.httpServer.Close()
+}
+
 func (s *server) registerRoute(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]

--- a/demos/counter/pkg/service/frontend/server.go
+++ b/demos/counter/pkg/service/frontend/server.go
@@ -107,6 +107,10 @@ func (s *server) registerRoute(w http.ResponseWriter, r *http.Request) {
 			websocket.BinaryMessage,
 			[]byte(strconv.FormatUint(count, 10)),
 		)
+	}, func(e error) {
+		s.logger.Error("counter", zap.Error(err))
+		// Close the connection so the read loop exits.
+		c.Close()
 	})
 	if err != nil {
 		return

--- a/demos/counter/pkg/service/frontend/service.go
+++ b/demos/counter/pkg/service/frontend/service.go
@@ -103,3 +103,11 @@ func (s *Service) GracefulStop() {
 	s.server.GracefulStop()
 	s.counter.Close()
 }
+
+func (s *Service) Stop() {
+	if err := s.registry.Unregister(); err != nil {
+		s.logger.Error("failed to unregister", zap.Error(err))
+	}
+	s.server.Stop()
+	s.counter.Close()
+}

--- a/demos/counter/pkg/testutils/cluster/cluster.go
+++ b/demos/counter/pkg/testutils/cluster/cluster.go
@@ -40,6 +40,16 @@ type Cluster struct {
 }
 
 func NewCluster(opts ...Option) (*Cluster, error) {
+	c := &Cluster{
+		counterNodes: make(map[string]string),
+	}
+	if err := c.AddNodes(opts...); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Cluster) AddNodes(opts ...Option) error {
 	options := options{
 		fuddleNodes:   0,
 		counterNodes:  0,
@@ -49,32 +59,29 @@ func NewCluster(opts ...Option) (*Cluster, error) {
 		o.apply(&options)
 	}
 
-	c := &Cluster{
-		counterNodes: make(map[string]string),
-	}
 	for i := 0; i != options.fuddleNodes; i++ {
 		if err := c.addFuddleNode(); err != nil {
-			return nil, fmt.Errorf("cluster: %w", err)
+			return fmt.Errorf("cluster: %w", err)
 		}
 	}
 	for i := 0; i != options.counterNodes; i++ {
 		if err := c.addCounterNode(); err != nil {
-			return nil, fmt.Errorf("cluster: %w", err)
+			return fmt.Errorf("cluster: %w", err)
 		}
 	}
 	for i := 0; i != options.frontendNodes; i++ {
 		if err := c.addFrontendNode(); err != nil {
-			return nil, fmt.Errorf("cluster: %w", err)
+			return fmt.Errorf("cluster: %w", err)
 		}
 	}
 
 	for _, s := range c.services {
 		if err := s.Start(); err != nil {
-			return nil, fmt.Errorf("cluster: %w", err)
+			return fmt.Errorf("cluster: %w", err)
 		}
 	}
 
-	return c, nil
+	return nil
 }
 
 func (c *Cluster) CounterNodes() map[string]string {

--- a/demos/counter/tests/counter/counter_test.go
+++ b/demos/counter/tests/counter/counter_test.go
@@ -45,6 +45,8 @@ func TestCounter_Register(t *testing.T) {
 	updates := make(chan uint64, 1)
 	unsubscribe, err := client.Register("foo", func(c uint64) {
 		updates <- c
+	}, func(e error) {
+		t.Error(e)
 	})
 	require.NoError(t, err)
 	defer func() {
@@ -62,7 +64,9 @@ func TestCounter_Register(t *testing.T) {
 		defer c.Close()
 
 		for j := 0; j != 3; j++ {
-			unsub, err := c.Register("foo", func(c uint64) {})
+			unsub, err := c.Register("foo", func(c uint64) {}, func(e error) {
+				t.Error(e)
+			})
 			require.NoError(t, err)
 			unregister = append(unregister, unsub)
 

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -97,6 +97,10 @@ func (s *server) GracefulStop() {
 	}
 }
 
+func (s *server) Stop() {
+	s.httpServer.Close()
+}
+
 func (s *server) clusterRoute(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(s.cluster.Nodes()); err != nil {
 		s.logger.Error("failed to encode cluster response", zap.Error(err))

--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -56,3 +56,8 @@ func (s *Service) GracefulStop() {
 	s.logger.Info("starting admin service graceful shutdown")
 	s.server.GracefulStop()
 }
+
+func (s *Service) Stop() {
+	s.logger.Info("starting admin service hard shutdown")
+	s.server.Stop()
+}

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -102,6 +102,10 @@ func (s *Server) GracefulStop() {
 	}
 }
 
+func (s *Server) Stop() {
+	s.httpServer.Close()
+}
+
 func (s *Server) registerRoute(w http.ResponseWriter, r *http.Request) {
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -80,6 +80,11 @@ func (s *Service) GracefulStop() {
 	s.server.GracefulStop()
 }
 
+func (s *Service) Stop() {
+	s.logger.Info("starting registry service hard shutdown")
+	s.server.Stop()
+}
+
 func (s *Service) Cluster() *cluster.Cluster {
 	return s.clusterState
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,3 +88,9 @@ func (s *Server) GracefulStop() {
 	s.registryService.GracefulStop()
 	s.adminService.GracefulStop()
 }
+
+func (s *Server) Stop() {
+	s.logger.Info("starting node hard shutdown")
+	s.registryService.Stop()
+	s.adminService.Stop()
+}


### PR DESCRIPTION
# Description
Add counter service rebalancing.

Using consistent hashing to partition the counter IDs across nodes, when the set of nodes changes the counter clients need to rebalance.

Since this is just a demo, to keep simple only the clients check for relocates. The servers simply accept any connection.

# Changes
* Refactors murmur3 partitioner to lookup more efficiently
* Adds counter client relocate

## Testing
Adds a counter service test where nodes are added and removes, and verifies the counter is correct after the rebalance.

## Docs
Already documented.