### PR TITLE
add message types

### DIFF
--- a/docs/architecture/registry_protocol.md
+++ b/docs/architecture/registry_protocol.md
@@ -1,0 +1,94 @@
+# Registry Protocol
+This document describes the protocol between a registered node and a Fuddle
+server.
+
+The protocol is intentionally simple to get something working quickly, though
+may improve later, such as moving to a gRPC API.
+
+## Transport
+Clients connect to the `/api/v1/register` WebSocket endpoint. Messages sent
+are encoded as JSON.
+
+## Message Format
+Each message contains a `string` message type and a payload for that type.
+
+Supported types:
+* `node_update`: Describes an update to the client nodes entry in the registry
+
+### `node_update`
+A node update message describes an update to a nodes entry in the registry.
+
+Each node update contains:
+* Node ID (`string`): The registered nodes ID
+* Update type (`string`): The type of update:
+	* `register`: A node has joined the cluster
+	* `unregister`: A node has left the cluster
+	* `metadata`: A nodes metadata has changed
+* Attributes: A nodes immutable attributes. Only sent when the node is
+registered
+* Metadata: The nodes application defined metadata, which are just string
+key-value pairs. The contents of this field depend on the update type:
+	* `register`: Contains all metadata fields
+	* `unregister`: Empty since theres no need to update the metadata of a leaving
+node
+	* `metadata`: Contains only the key-value pairs that have been updated
+
+Node attributes include:
+* Service (`string`): The type of service running on the node
+* Locality (`string`): The location of the node
+* Created (`int64`): The UNIX timestamp in milliseconds that the node was
+created
+* Revision (`string`): An identifier for the version of the service running on
+the node, such as a Git tag or commit SHA
+
+## Protocol
+
+### Node Register
+Client send `node_update` messages to Fuddle when their local node changes:
+* `register`: When the client first connects it sends a `register` update
+including its nodes information
+* `metadata`: When the client nodes metadata is updated, it is sent to update
+its entry in the registry,
+* `unregister`: When the client node is shutdown it sends an `unregister` to
+gracefully remove itself from the registry
+
+Once registered, each client streams the registry state and any future updates
+to build its own eventually consistent view of the registry.
+
+When the client is registered, the server will send a set of `register`
+updates, each containing information on a node in the cluster. Once the client
+is up to date, all further node updates sent to the Fuddle registry will be
+forwarded to all connected clients.
+
+```mermaid
+sequenceDiagram
+    participant C1 as Client1
+    participant C2 as Client2
+    participant C3 as Client3
+    participant S as Server
+
+    C1->>+S: register [id=client1]
+    Note right of S: Aggregate: client1 registered
+
+    C2->>+S: register [id=client2]
+    Note right of S: Aggregate: client2 registered
+    S-->>+C2: register [id=client1]
+    S-->>+C1: register [id=client2]
+
+    C3->>+S: register [id=client3]
+    Note right of S: Aggregate: client3 registered
+    S-->>+C3: register [id=client1]
+    S-->>+C3: register [id=client2]
+    S-->>+C1: register [id=client3]
+    S-->>+C2: register [id=client3]
+
+    C1->>+S: metadata [id=client1]
+    Note right of S: Aggregate: client1 updated
+    S-->>+C2: metadata [id=client1]
+    S-->>+C3: metadata [id=client1]
+
+    C2->>+S: unregister [id=client2]
+    Note right of S: Aggregate: client2 unregistered
+    S-->>+C1: unregister [id=client2]
+    S-->>+C3: unregister [id=client2]
+```

--- a/docs/rfcs/20230318_node_failure_detector.md
+++ b/docs/rfcs/20230318_node_failure_detector.md
@@ -25,6 +25,13 @@ server.
 Since clients can disconnect due to brief network disruption or connection
 rebalancing, the clients connection is independent of failure detection.
 
+# Registry API
+Adds new `ping` and `pong` update types to the registry API stream described
+in [`20230303_registry_api.md`](./20230303_registry_api.md).
+
+`ping` and `pong` updates include an `int64` `timestamp` field which is set
+by the client and echoed back by the server.
+
 # Operating
 
 ## Metrics

--- a/docs/rfcs/20230319_node_reconnect_support.md
+++ b/docs/rfcs/20230319_node_reconnect_support.md
@@ -57,10 +57,6 @@ sending a `sync`, though the node is not registered (likely due to missing too
 many heartbeats), the server will respond with a `NOT_REGISTERED` error causing
 the client to re-register itself.
 
-### `ping` and `pong`
-The `ping` and `pong` types are used for heartbeats, which add a new `timestamp`
-field which is set by the client and echoed back by the server.
-
 # Reconnect Strategy
 To avoid clients generating excessive load, they must use exponential backoff
 with jitter when trying to reconnect to a Fuddle server.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fuddle-io/fuddle
 go 1.20
 
 require (
-	github.com/fuddle-io/fuddle-go v0.1.0
+	github.com/fuddle-io/fuddle-go v0.1.1-0.20230319142329-c94894d34340
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fuddle-io/fuddle-go v0.1.0 h1:saARvvXsVlfoIcgQEtXJHaFOsUkty3LQ9WEQr3rpKnE=
 github.com/fuddle-io/fuddle-go v0.1.0/go.mod h1:hE2vV7fYXul454JgKvG0Q0UDaVyUbkY9EfY+oFmK9Oc=
+github.com/fuddle-io/fuddle-go v0.1.1-0.20230319142329-c94894d34340 h1:cZYsRdhQs1MUiPCiJHMB+3QN3yFbUSMpd62DNfgqFWE=
+github.com/fuddle-io/fuddle-go v0.1.1-0.20230319142329-c94894d34340/go.mod h1:hE2vV7fYXul454JgKvG0Q0UDaVyUbkY9EfY+oFmK9Oc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/registry/server/message.go
+++ b/pkg/registry/server/message.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"github.com/fuddle-io/fuddle/pkg/registry/cluster"
+)
+
+type messageType string
+
+const (
+	messageTypeNodeUpdate messageType = "node_update"
+)
+
+type message struct {
+	MessageType messageType `json:"message_type,omitempty"`
+
+	NodeUpdate *cluster.NodeUpdate `json:"node_update,omitempty"`
+}


### PR DESCRIPTION
# Description
Adds a message type for the registry protocol.

## Testing
Already covered by existing tests.

## Docs
Adds `docs/architecture/registry_protocol.md` to describe the protocol.

## Compatibility
Breaking change though thats ok as this is an early release.
