### PR TITLE
registry: add v2 registry server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/fuddle-io/fuddle-go v0.1.1-0.20230322070343-3933ef167b2b
-	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230322065350-85501b751765
+	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230323053844-a7eb3fce9135
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fuddle-io/fuddle-go v0.1.1-0.20230322070343-3933ef167b2b h1:xtQS2dOnkHP5f+iAKM7w+M33HfeFqa3HA0RCsCqMpdU=
 github.com/fuddle-io/fuddle-go v0.1.1-0.20230322070343-3933ef167b2b/go.mod h1:JvRWwio0bqk4wPAC0oP/ZOukLmc1G4z1cdA8dgVLkd0=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230322065350-85501b751765 h1:PvBSSdGf3PCNUSSG6GAJ+r6R4JaWShRm70sflbrqWn8=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230322065350-85501b751765/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230323053844-a7eb3fce9135 h1:5npLUCCJN8vcrQPm/E4Sq0o4zHvlYDS4fiQJCKLHEW0=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230323053844-a7eb3fce9135/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/registryv2/registry/registry.go
+++ b/pkg/registryv2/registry/registry.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package registry
+
+import (
+	"fmt"
+	"sync"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+)
+
+var (
+	ErrAlreadyRegistered = fmt.Errorf("node already registered")
+	ErrNotFound          = fmt.Errorf("not found")
+	ErrInvalidUpdate     = fmt.Errorf("invalid update")
+)
+
+type Registry struct {
+	nodes map[string]*rpc.Node
+
+	// mu protects the fields above.
+	mu sync.Mutex
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		nodes: make(map[string]*rpc.Node),
+	}
+}
+
+func (r *Registry) Node(id string) (*rpc.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if n, ok := r.nodes[id]; ok {
+		return n, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (r *Registry) Nodes(includeMetadata bool) []*rpc.Node {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var nodes []*rpc.Node
+	for _, node := range r.nodes {
+		// Copy to modify metadata.
+		node := CopyNode(node)
+		if !includeMetadata {
+			node.Metadata = nil
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}
+
+func (r *Registry) Register(node *rpc.Node) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if node.Id == "" || node.Attributes == nil || node.Metadata == nil {
+		return ErrInvalidUpdate
+	}
+
+	if _, ok := r.nodes[node.Id]; ok {
+		return ErrAlreadyRegistered
+	}
+
+	r.nodes[node.Id] = node
+
+	return nil
+}
+
+func (r *Registry) Unregister(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// If the ID is not found do nothing.
+	delete(r.nodes, id)
+
+	return nil
+}
+
+func (r *Registry) UpdateNode(id string, metadata map[string]string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	n, ok := r.nodes[id]
+	if !ok {
+		return ErrNotFound
+	}
+
+	if metadata == nil {
+		return ErrInvalidUpdate
+	}
+
+	for k, v := range metadata {
+		n.Metadata[k] = &rpc.VersionedValue{
+			Value: v,
+		}
+	}
+
+	return nil
+}
+
+func CopyNode(n *rpc.Node) *rpc.Node {
+	metadata := make(map[string]*rpc.VersionedValue)
+	for k, v := range n.Metadata {
+		metadata[k] = &rpc.VersionedValue{
+			Value:   v.Value,
+			Version: v.Version,
+		}
+	}
+
+	return &rpc.Node{
+		Id: n.Id,
+		Attributes: &rpc.NodeAttributes{
+			Service:  n.Attributes.Service,
+			Locality: n.Attributes.Locality,
+			Created:  n.Attributes.Created,
+			Revision: n.Attributes.Revision,
+		},
+		Metadata: metadata,
+	}
+}

--- a/pkg/registryv2/registry/registry_test.go
+++ b/pkg/registryv2/registry/registry_test.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package registry
+
+import (
+	"sort"
+	"testing"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestRegistry_RegisterThenQueryNode(t *testing.T) {
+	r := NewRegistry()
+
+	registeredNode := testutils.RandomRPCNode()
+	assert.NoError(t, r.Register(registeredNode))
+
+	n, err := r.Node(registeredNode.Id)
+	assert.NoError(t, err)
+	assert.True(t, proto.Equal(n, registeredNode))
+}
+
+func TestRegistry_RegisterThenUnregister(t *testing.T) {
+	r := NewRegistry()
+
+	registeredNode := testutils.RandomRPCNode()
+	assert.NoError(t, r.Register(registeredNode))
+	assert.NoError(t, r.Unregister(registeredNode.Id))
+
+	_, err := r.Node(registeredNode.Id)
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestRegistry_NodeNotFound(t *testing.T) {
+	r := NewRegistry()
+
+	_, err := r.Node("foo")
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestRegistry_RegisterInvalidUpdate(t *testing.T) {
+	r := NewRegistry()
+
+	nodeMissingID := testutils.RandomRPCNode()
+	nodeMissingID.Id = ""
+
+	nodeMissingAttrs := testutils.RandomRPCNode()
+	nodeMissingAttrs.Attributes = nil
+
+	nodeMissingMetadata := testutils.RandomRPCNode()
+	nodeMissingMetadata.Metadata = nil
+
+	tests := []struct {
+		Name string
+		Node *rpc.Node
+	}{
+		{
+			Name: "missing id",
+			Node: nodeMissingID,
+		},
+		{
+			Name: "missing attrs",
+			Node: nodeMissingAttrs,
+		},
+		{
+			Name: "missing metadata",
+			Node: nodeMissingMetadata,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			assert.Equal(t, ErrInvalidUpdate, r.Register(tt.Node))
+		})
+	}
+}
+
+func TestRegistry_RegisterAlreadyRegister(t *testing.T) {
+	r := NewRegistry()
+
+	registeredNode := testutils.RandomRPCNode()
+	assert.NoError(t, r.Register(registeredNode))
+
+	// Register the same node again which should fail.
+	assert.Equal(t, ErrAlreadyRegistered, r.Register(registeredNode))
+}
+
+func TestRegistry_UpdateNode(t *testing.T) {
+	r := NewRegistry()
+
+	registeredNode := testutils.RandomRPCNode()
+	assert.NoError(t, r.Register(registeredNode))
+
+	update := testutils.RandomMetadata()
+	assert.NoError(t, r.UpdateNode(registeredNode.Id, update))
+
+	expectedNode := CopyNode(registeredNode)
+	for k, v := range update {
+		expectedNode.Metadata[k] = &rpc.VersionedValue{
+			Value: v,
+		}
+	}
+
+	n, err := r.Node(registeredNode.Id)
+	assert.NoError(t, err)
+	assert.True(t, proto.Equal(n, expectedNode))
+}
+
+func TestRegistry_UpdateNodeNilMetadata(t *testing.T) {
+	r := NewRegistry()
+
+	registeredNode := testutils.RandomRPCNode()
+	assert.NoError(t, r.Register(registeredNode))
+
+	assert.Equal(t, ErrInvalidUpdate, r.UpdateNode(registeredNode.Id, nil))
+}
+
+func TestRegistry_UpdateNodeNotFound(t *testing.T) {
+	r := NewRegistry()
+
+	assert.Equal(t, ErrNotFound, r.UpdateNode("foo", map[string]string{"a": "b"}))
+}
+
+func TestRegistry_Nodes(t *testing.T) {
+	r := NewRegistry()
+
+	var nodes []*rpc.Node
+	for i := 0; i != 10; i++ {
+		registeredNode := testutils.RandomRPCNode()
+		assert.NoError(t, r.Register(registeredNode))
+
+		nodes = append(nodes, registeredNode)
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Id < nodes[j].Id
+	})
+
+	nodesWithMetadata := r.Nodes(true)
+	sort.Slice(nodesWithMetadata, func(i, j int) bool {
+		return nodesWithMetadata[i].Id < nodesWithMetadata[j].Id
+	})
+
+	assert.Equal(t, 10, len(nodesWithMetadata))
+	for i := 0; i != 10; i++ {
+		assert.True(t, proto.Equal(nodes[i], nodesWithMetadata[i]))
+	}
+}

--- a/pkg/registryv2/server/options.go
+++ b/pkg/registryv2/server/options.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"go.uber.org/zap"
+)
+
+type options struct {
+	logger *zap.Logger
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type loggerOption struct {
+	logger *zap.Logger
+}
+
+func (o loggerOption) apply(opts *options) {
+	opts.logger = o.logger
+}
+
+func WithLogger(logger *zap.Logger) Option {
+	return loggerOption{logger: logger}
+}

--- a/pkg/registryv2/server/server.go
+++ b/pkg/registryv2/server/server.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"context"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/registryv2/registry"
+	"go.uber.org/zap"
+)
+
+type Server struct {
+	registry *registry.Registry
+
+	logger *zap.Logger
+}
+
+func NewServer(registry *registry.Registry, opts ...Option) *Server {
+	options := options{
+		logger: zap.NewNop(),
+	}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	return &Server{
+		registry: registry,
+		logger:   options.logger,
+	}
+}
+
+func (s *Server) RegisterV2(ctx context.Context, req *rpc.RegisterRequest) (*rpc.RegisterResponse, error) {
+	logger := s.logger.With(zap.String("rpc", "registry.RegisterV2"))
+
+	err := s.registry.Register(req.Node)
+	if err == registry.ErrAlreadyRegistered {
+		logger.Warn(
+			"node already registered",
+			zap.String("id", req.Node.Id),
+		)
+
+		return &rpc.RegisterResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_ALREADY_REGISTERED,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	if err == registry.ErrInvalidUpdate {
+		logger.Warn(
+			"invalid node",
+			zap.String("id", req.Node.Id),
+		)
+
+		return &rpc.RegisterResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_PROTOCOL,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	if err != nil {
+		logger.Error(
+			"unknown error",
+			zap.String("id", req.Node.Id),
+		)
+
+		return &rpc.RegisterResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_UNKNOWN,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+
+	logger.Debug(
+		"node registered",
+		zap.String("id", req.Node.Id),
+	)
+
+	return &rpc.RegisterResponse{}, nil
+}
+
+func (s *Server) Unregister(ctx context.Context, req *rpc.UnregisterRequest) (*rpc.UnregisterResponse, error) {
+	logger := s.logger.With(zap.String("rpc", "registry.Unregister"))
+
+	if err := s.registry.Unregister(req.NodeId); err != nil {
+		logger.Error(
+			"unknown error",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.UnregisterResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_UNKNOWN,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	return &rpc.UnregisterResponse{}, nil
+}
+
+func (s *Server) UpdateNode(ctx context.Context, req *rpc.UpdateNodeRequest) (*rpc.UpdateNodeResponse, error) {
+	logger := s.logger.With(zap.String("rpc", "registry.Unregister"))
+
+	err := s.registry.UpdateNode(req.NodeId, req.Metadata)
+
+	if err == registry.ErrNotFound {
+		logger.Warn(
+			"node not found",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.UpdateNodeResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_NOT_FOUND,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	if err == registry.ErrInvalidUpdate {
+		logger.Warn(
+			"invalid update",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.UpdateNodeResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_PROTOCOL,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	if err != nil {
+		logger.Error(
+			"unknown error",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.UpdateNodeResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_UNKNOWN,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+
+	return &rpc.UpdateNodeResponse{}, nil
+}
+
+func (s *Server) Updates(req *rpc.UpdatesRequest, stream rpc.Registry_UpdatesServer) error {
+	return nil
+}
+
+func (s *Server) Node(ctx context.Context, req *rpc.NodeRequest) (*rpc.NodeResponse, error) {
+	logger := s.logger.With(zap.String("rpc", "registry.Node"))
+
+	n, err := s.registry.Node(req.NodeId)
+	if err == registry.ErrNotFound {
+		logger.Debug(
+			"node not found",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.NodeResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_NOT_FOUND,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+	if err != nil {
+		logger.Error(
+			"unknown error",
+			zap.String("id", req.NodeId),
+		)
+
+		return &rpc.NodeResponse{
+			Error: &rpc.Error{
+				Status:      rpc.ErrorStatus_UNKNOWN,
+				Description: err.Error(),
+			},
+		}, nil
+	}
+
+	logger.Debug(
+		"node found",
+		zap.String("id", req.NodeId),
+	)
+
+	return &rpc.NodeResponse{
+		Node: n,
+	}, nil
+}
+
+func (s *Server) Nodes(ctx context.Context, req *rpc.NodesRequest) (*rpc.NodesResponse, error) {
+	nodes := s.registry.Nodes(req.IncludeMetadata)
+	return &rpc.NodesResponse{
+		Nodes: nodes,
+	}, nil
+}

--- a/pkg/registryv2/server/server_test.go
+++ b/pkg/registryv2/server/server_test.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/registryv2/registry"
+	"github.com/fuddle-io/fuddle/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestServer_RegisterThenQueryNode(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+	_, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+
+	resp, err := s.Node(context.Background(), &rpc.NodeRequest{
+		NodeId: registeredNode.Id,
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, proto.Equal(resp.Node, registeredNode))
+}
+
+func TestServer_RegisterThenUnregisterNode(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+	_, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+
+	_, err = s.Unregister(context.Background(), &rpc.UnregisterRequest{
+		NodeId: registeredNode.Id,
+	})
+	assert.NoError(t, err)
+
+	resp, err := s.Node(context.Background(), &rpc.NodeRequest{
+		NodeId: registeredNode.Id,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_NOT_FOUND, resp.Error.Status)
+}
+
+func TestServer_NodeNotFound(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	resp, err := s.Node(context.Background(), &rpc.NodeRequest{
+		NodeId: "foo",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_NOT_FOUND, resp.Error.Status)
+}
+
+func TestServer_RegisterInvalidNode(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+	// Set empty ID.
+	registeredNode.Id = ""
+
+	resp, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_PROTOCOL, resp.Error.Status)
+}
+
+func TestServer_RegisterAlreadyRegister(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+
+	resp, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, resp.Error)
+
+	resp, err = s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_ALREADY_REGISTERED, resp.Error.Status)
+}
+
+func TestServer_UpdateNode(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+
+	regResp, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, regResp.Error)
+
+	update := testutils.RandomMetadata()
+	updateResp, err := s.UpdateNode(context.Background(), &rpc.UpdateNodeRequest{
+		NodeId:   registeredNode.Id,
+		Metadata: update,
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, updateResp.Error)
+
+	expectedNode := registry.CopyNode(registeredNode)
+	for k, v := range update {
+		expectedNode.Metadata[k] = &rpc.VersionedValue{
+			Value: v,
+		}
+	}
+
+	nodeResp, err := s.Node(context.Background(), &rpc.NodeRequest{
+		NodeId: registeredNode.Id,
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, proto.Equal(nodeResp.Node, expectedNode))
+}
+
+func TestServer_UpdateNodeNilMetadata(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	registeredNode := testutils.RandomRPCNode()
+
+	regResp, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+		Node: registeredNode,
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, regResp.Error)
+
+	updateResp, err := s.UpdateNode(context.Background(), &rpc.UpdateNodeRequest{
+		NodeId:   registeredNode.Id,
+		Metadata: nil,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_PROTOCOL, updateResp.Error.Status)
+}
+
+func TestServer_UpdateNodeNotFound(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	resp, err := s.UpdateNode(context.Background(), &rpc.UpdateNodeRequest{
+		NodeId: "foo",
+		Metadata: map[string]string{
+			"bar": "car",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rpc.ErrorStatus_NOT_FOUND, resp.Error.Status)
+}
+
+func TestServer_Nodes(t *testing.T) {
+	s := NewServer(registry.NewRegistry())
+
+	var nodes []*rpc.Node
+	for i := 0; i != 10; i++ {
+		registeredNode := testutils.RandomRPCNode()
+
+		_, err := s.RegisterV2(context.Background(), &rpc.RegisterRequest{
+			Node: registeredNode,
+		})
+		assert.NoError(t, err)
+
+		nodes = append(nodes, registeredNode)
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Id < nodes[j].Id
+	})
+
+	resp, err := s.Nodes(context.Background(), &rpc.NodesRequest{
+		IncludeMetadata: true,
+	})
+	assert.NoError(t, err)
+
+	nodesWithMetadata := resp.Nodes
+	sort.Slice(nodesWithMetadata, func(i, j int) bool {
+		return nodesWithMetadata[i].Id < nodesWithMetadata[j].Id
+	})
+
+	assert.Equal(t, 10, len(nodesWithMetadata))
+	for i := 0; i != 10; i++ {
+		assert.True(t, proto.Equal(nodes[i], nodesWithMetadata[i]))
+	}
+}

--- a/pkg/testutils/node.go
+++ b/pkg/testutils/node.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	fuddle "github.com/fuddle-io/fuddle-go"
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
 	"github.com/fuddle-io/fuddle/pkg/registry/cluster"
 	"github.com/google/uuid"
 )
@@ -82,6 +83,21 @@ func RandomRegistryNode() cluster.Node {
 	}
 }
 
+// RandomRPCNode returns a node with random attributes and state.
+func RandomRPCNode() *rpc.Node {
+	metadata := RandomVersionedMetadata()
+	return &rpc.Node{
+		Id: uuid.New().String(),
+		Attributes: &rpc.NodeAttributes{
+			Service:  uuid.New().String(),
+			Locality: uuid.New().String(),
+			Created:  rand.Int63(),
+			Revision: uuid.New().String(),
+		},
+		Metadata: metadata,
+	}
+}
+
 func RandomMetadata() map[string]string {
 	return map[string]string{
 		uuid.New().String(): uuid.New().String(),
@@ -90,4 +106,16 @@ func RandomMetadata() map[string]string {
 		uuid.New().String(): uuid.New().String(),
 		uuid.New().String(): uuid.New().String(),
 	}
+}
+
+func RandomVersionedMetadata() map[string]*rpc.VersionedValue {
+	metadata := make(map[string]*rpc.VersionedValue)
+	for i := 0; i != 5; i++ {
+		version := rand.Uint64()
+		metadata[uuid.New().String()] = &rpc.VersionedValue{
+			Value:   uuid.New().String(),
+			Version: version,
+		}
+	}
+	return metadata
 }


### PR DESCRIPTION
# Description
Adds a new V2 registry server.

## Testing
The server has good unit test test coverage. Will add integration tests once the Go SDK is written.

## Docs
Will add API docs later.

## Admin
Adds admin API endpoints as part of V2.

## Metrics
Adding metrics later.
