### PR TITLE
registry: rewrite pkg/registry/registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230407174812-59c8890c9ec2
+	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-sockaddr v1.0.0
 	github.com/hashicorp/memberlist v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230407174812-59c8890c9ec2 h1:eSUQ0HY0m58iRommAf188GeqGwp3wIATxtuGJRFUT6Q=
 github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230407174812-59c8890c9ec2/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28 h1:FFjjF5g7xytRSIpFeYvAwL+Il3ahQHPWtImdALAOM8g=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=

--- a/pkg/fuddle/fuddle.go
+++ b/pkg/fuddle/fuddle.go
@@ -139,7 +139,7 @@ func (f *Fuddle) failureDetector() {
 		case <-f.done:
 			return
 		case <-ticker.C:
-			f.registry.MarkDownNodes()
+			f.registry.CheckMembersLiveness()
 		}
 	}
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -105,7 +105,8 @@ func (c *Client) onConnected() {
 	stream, err := c.client.Subscribe(
 		context.Background(),
 		&rpc.SubscribeRequest{
-			OwnerOnly: true,
+			OwnerOnly:    true,
+			KnownMembers: make(map[string]*rpc.Version),
 		},
 	)
 	if err != nil {

--- a/pkg/registry/doc.go
+++ b/pkg/registry/doc.go
@@ -1,0 +1,5 @@
+// Package registry implements the registry which maintains the registered
+// set of members.
+//
+// See docs/architecture/registry for details.
+package registry

--- a/pkg/registry/logger.go
+++ b/pkg/registry/logger.go
@@ -57,26 +57,6 @@ func (l memberLogger) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	return nil
 }
 
-type localMemberUpdateLogger struct {
-	UpdateType rpc.MemberUpdateType
-	Member     *memberLogger
-}
-
-func newLocalMemberUpdateLogger(u *rpc.LocalMemberUpdate) *localMemberUpdateLogger {
-	return &localMemberUpdateLogger{
-		UpdateType: u.UpdateType,
-		Member:     newMemberLogger(u.Member),
-	}
-}
-
-func (l localMemberUpdateLogger) MarshalLogObject(e zapcore.ObjectEncoder) error {
-	e.AddString("update-type", l.UpdateType.String())
-	if err := e.AddObject("member", l.Member); err != nil {
-		return err
-	}
-	return nil
-}
-
 type remoteMemberUpdateLogger struct {
 	UpdateType rpc.MemberUpdateType
 	Member     *memberLogger

--- a/pkg/registry/server.go
+++ b/pkg/registry/server.go
@@ -59,7 +59,7 @@ func (s *Server) Register(stream rpc.Registry_RegisterServer) error {
 	}
 
 	member := m.Member
-	s.registry.LocalRegister(member)
+	s.registry.AddMember(member)
 
 	if err := stream.Send(&rpc.ClientAck{
 		SeqId: m.SeqId,
@@ -75,15 +75,15 @@ func (s *Server) Register(stream rpc.Registry_RegisterServer) error {
 
 		if m.UpdateType == rpc.ClientUpdateType_CLIENT_REGISTER {
 			member = m.Member
-			s.registry.LocalRegister(member)
+			s.registry.AddMember(member)
 		}
 
 		if m.UpdateType == rpc.ClientUpdateType_CLIENT_HEARTBEAT {
-			s.registry.LocalRegister(member)
+			s.registry.AddMember(member)
 		}
 
 		if m.UpdateType == rpc.ClientUpdateType_CLIENT_UNREGISTER {
-			s.registry.LocalUnregister(member.Id)
+			s.registry.RemoveMember(member.Id)
 			return nil
 		}
 


### PR DESCRIPTION
Rewrites pkg/registry/registry to improve test coverage and handle unregisters better.

Adds full unit test coverage.
