### PR TITLE
add info cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-sockaddr v1.0.0
 	github.com/hashicorp/memberlist v0.5.0
+	github.com/rodaine/table v1.1.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28
+	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230410054709-5e25e3169910
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-sockaddr v1.0.0
 	github.com/hashicorp/memberlist v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28 h1:FFjjF5g7xytRSIpFeYvAwL+Il3ahQHPWtImdALAOM8g=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230408063749-0256f64e7c28/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230410054709-5e25e3169910 h1:UnDsKCP5CGGYCuFWcCjeprMAXsusoVq3wpMd5cANCzo=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230410054709-5e25e3169910/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCy
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -34,6 +35,8 @@ github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/miekg/dns v1.1.26 h1:gPxPSwALAeHJSjarOs00QjVdV9QoBvc1D2ujQUr5BzU=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
@@ -41,6 +44,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rodaine/table v1.1.0 h1:/fUlCSdjamMY8VifdQRIu3VWZXYLY7QHFkVorS8NTr4=
+github.com/rodaine/table v1.1.0/go.mod h1:Qu3q5wi1jTQD6B6HsP6szie/S4w1QUQ8pq22pz9iL8g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -52,6 +57,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/pkg/admin/client.go
+++ b/pkg/admin/client.go
@@ -1,0 +1,79 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type Client struct {
+	addr   string
+	conn   *grpc.ClientConn
+	client rpc.RegistryClient
+}
+
+func Connect(addr string, opts ...Option) (*Client, error) {
+	options := options{
+		connectTimeout: time.Second,
+	}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	conn, client, err := connect(addr, options.connectTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("admin client: connect: %w", err)
+	}
+	return &Client{
+		addr:   addr,
+		conn:   conn,
+		client: client,
+	}, nil
+}
+
+func (c *Client) Members(ctx context.Context) ([]*rpc.Member, error) {
+	resp, err := c.client.Members(ctx, &rpc.MembersRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("admin client: members: %w", err)
+	}
+	return resp.Members, nil
+}
+
+func (c *Client) Member(ctx context.Context, id string) (*rpc.Member, error) {
+	resp, err := c.client.Member(ctx, &rpc.MemberRequest{
+		Id: id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("admin client: member: %w", err)
+	}
+	if resp.Member == nil {
+		return nil, fmt.Errorf("admin client: member: not found")
+	}
+
+	return resp.Member, nil
+}
+
+func (c *Client) Close() {
+	c.conn.Close()
+}
+
+func connect(addr string, timeout time.Duration) (*grpc.ClientConn, rpc.RegistryClient, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(
+		ctx,
+		addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect: %w", err)
+	}
+
+	client := rpc.NewRegistryClient(conn)
+	return conn, client, nil
+}

--- a/pkg/admin/options.go
+++ b/pkg/admin/options.go
@@ -1,0 +1,27 @@
+package admin
+
+import (
+	"time"
+)
+
+type options struct {
+	connectTimeout time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type connectTimeoutOption struct {
+	timeout time.Duration
+}
+
+func (o connectTimeoutOption) apply(opts *options) {
+	opts.connectTimeout = o.timeout
+}
+
+// WithConnectTimeout defines the time to wait for each connection attempt
+// before timing out. Default to 1 second.
+func WithConnectTimeout(timeout time.Duration) Option {
+	return connectTimeoutOption{timeout: timeout}
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/fuddle-io/fuddle/pkg/cli/start"
+	"github.com/fuddle-io/fuddle/pkg/cli/info"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,7 @@ func init() {
 
 	fuddleCmd.AddCommand(
 		start.Command,
+		info.Command,
 	)
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
-	"github.com/fuddle-io/fuddle/pkg/cli/start"
 	"github.com/fuddle-io/fuddle/pkg/cli/info"
+	"github.com/fuddle-io/fuddle/pkg/cli/start"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/info/command.go
+++ b/pkg/cli/info/command.go
@@ -1,0 +1,122 @@
+package info
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/admin"
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "info",
+	Short: "inspect the status of the cluster",
+}
+
+var clusterCommand = &cobra.Command{
+	Use:   "cluster",
+	Short: "inspect the status of the cluster",
+	Long: `
+Inspect the status of the cluster.
+
+Displays an overview of the cluster status and a list of members in the cluster.
+`,
+	RunE: runClusterStatus,
+}
+
+var memberCommand = &cobra.Command{
+	Use:   "member",
+	Short: "inspect the status of a member",
+	Long: `
+Inspect the status of a member.
+`,
+	RunE: runMemberStatus,
+}
+
+func init() {
+	Command.AddCommand(
+		clusterCommand,
+		memberCommand,
+	)
+}
+
+func runClusterStatus(cmd *cobra.Command, args []string) error {
+	client, err := admin.Connect(addr)
+	if err != nil {
+		return err
+	}
+	members, err := client.Members(context.Background())
+	if err != nil {
+		return err
+	}
+
+	displayMembers(members)
+
+	return nil
+}
+
+func runMemberStatus(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing member ID")
+	}
+
+	id := args[0]
+
+	client, err := admin.Connect(addr)
+	if err != nil {
+		return err
+	}
+	member, err := client.Member(context.Background(), id)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("ID:", member.Id)
+	fmt.Println("Status:", member.Status)
+	fmt.Println("Service:", member.Service)
+	fmt.Println("Locality:", member.Locality)
+	fmt.Println("Created:", member.Created)
+	fmt.Println("Revision:", member.Revision)
+	fmt.Println("Metadata:")
+
+	keys := []string{}
+	for key := range member.Metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Printf("    %s: %s\n", key, member.Metadata[key])
+	}
+
+	return nil
+}
+
+func displayMembers(members []*rpc.Member) {
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].Id < members[j].Id
+	})
+
+	tbl := table.New("ID", "Status", "Service", "Locality", "Created", "Revision")
+	for _, member := range members {
+		tbl.AddRow(
+			member.Id,
+			member.Status,
+			member.Service,
+			member.Locality,
+			member.Created,
+			formatRevision(member.Revision),
+		)
+	}
+
+	tbl.Print()
+}
+
+func formatRevision(revision string) string {
+	if len(revision) > 25 {
+		return revision[:25] + "..."
+	}
+	return revision
+}

--- a/pkg/cli/info/flags.go
+++ b/pkg/cli/info/flags.go
@@ -1,0 +1,15 @@
+package info
+
+var (
+	// addr is the Fuddle registry server to query.
+	addr string
+)
+
+func init() {
+	Command.PersistentFlags().StringVarP(
+		&addr,
+		"addr", "a",
+		"localhost:8110",
+		"address of the Fuddle server to query",
+	)
+}

--- a/pkg/fuddle/fuddle.go
+++ b/pkg/fuddle/fuddle.go
@@ -42,7 +42,10 @@ func NewFuddle(conf *config.Config, opts ...Option) (*Fuddle, error) {
 	r := registry.NewRegistry(
 		conf.NodeID,
 		registry.WithRegistryLocalMember(&rpc.Member{
-			Id: conf.NodeID,
+			Id:       conf.NodeID,
+			Service:  "fuddle",
+			Created:  time.Now().UnixMilli(),
+			Revision: "unknown",
 		}),
 		registry.WithRegistryLogger(
 			logger.With(zap.String("stream", "registry")),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -108,6 +108,17 @@ func (r *Registry) Member(id string) (*rpc.Member, bool) {
 	return m.Member, ok
 }
 
+func (r *Registry) Members() []*rpc.Member {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	members := make([]*rpc.Member, 0, len(r.members))
+	for _, m := range r.members {
+		members = append(members, m.Member)
+	}
+	return members
+}
+
 func (r *Registry) UpMembers() []*VersionedMember {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/registry/server.go
+++ b/pkg/registry/server.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"context"
+
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
 	"go.uber.org/zap"
 )
@@ -93,4 +95,17 @@ func (s *Server) Register(stream rpc.Registry_RegisterServer) error {
 			return nil
 		}
 	}
+}
+
+func (s *Server) Member(ctx context.Context, req *rpc.MemberRequest) (*rpc.MemberResponse, error) {
+	m, _ := s.registry.Member(req.Id)
+	return &rpc.MemberResponse{
+		Member: m,
+	}, nil
+}
+
+func (s *Server) Members(ctx context.Context, req *rpc.MembersRequest) (*rpc.MembersResponse, error) {
+	return &rpc.MembersResponse{
+		Members: s.registry.Members(),
+	}, nil
 }

--- a/tests/registry/admin_test.go
+++ b/tests/registry/admin_test.go
@@ -1,0 +1,197 @@
+//go:build all || integration
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/admin"
+	fuddle "github.com/fuddle-io/fuddle/pkg/sdk"
+	"github.com/fuddle-io/fuddle/pkg/testutils"
+	"github.com/fuddle-io/fuddle/tests/cluster"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAdmin_ListMembers(t *testing.T) {
+	t.Parallel()
+
+	c, err := cluster.NewCluster(cluster.WithNodes(5))
+	require.Nil(t, err)
+	defer c.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	assert.NoError(t, c.WaitForHealthy(ctx))
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	var clients []*fuddle.Fuddle
+	for i := 0; i != 10; i++ {
+		client, err := fuddle.Register(
+			ctx,
+			c.RPCAddrs(),
+			randomMember(fmt.Sprintf("member-%d", i)),
+			fuddle.WithLogger(testutils.Logger()),
+		)
+		require.NoError(t, err)
+		defer client.Close()
+
+		clients = append(clients, client)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*15)
+	defer cancel()
+
+	for _, client := range clients {
+		assert.NoError(t, waitForMembers(ctx, client, 15))
+	}
+
+	expectedMembers := clients[0].Members()
+
+	adminClient, err := admin.Connect(c.Nodes()[0].Fuddle.Config.RPC.JoinAdvAddr())
+	assert.NoError(t, err)
+
+	// List the members via the admin client and check the result matches the
+	// registry view.
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	members, err := adminClient.Members(ctx)
+	assert.NoError(t, err)
+
+	var sdkMembers []fuddle.Member
+	for _, m := range members {
+		sdkMembers = append(sdkMembers, fromRPC(m))
+	}
+
+	sortMembers(expectedMembers)
+	sortMembers(sdkMembers)
+	assert.Equal(t, expectedMembers, sdkMembers)
+}
+
+func TestAdmin_GetMember(t *testing.T) {
+	t.Parallel()
+
+	c, err := cluster.NewCluster(cluster.WithNodes(5))
+	require.Nil(t, err)
+	defer c.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	assert.NoError(t, c.WaitForHealthy(ctx))
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	var clients []*fuddle.Fuddle
+	for i := 0; i != 10; i++ {
+		client, err := fuddle.Register(
+			ctx,
+			c.RPCAddrs(),
+			randomMember(fmt.Sprintf("member-%d", i)),
+			fuddle.WithLogger(testutils.Logger()),
+		)
+		require.NoError(t, err)
+		defer client.Close()
+
+		clients = append(clients, client)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*15)
+	defer cancel()
+
+	for _, client := range clients {
+		assert.NoError(t, waitForMembers(ctx, client, 15))
+	}
+
+	adminClient, err := admin.Connect(c.Nodes()[0].Fuddle.Config.RPC.JoinAdvAddr())
+	assert.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	member, err := adminClient.Member(ctx, "member-5")
+	assert.NoError(t, err)
+
+	expected, _ := c.Nodes()[0].Fuddle.Registry().Member("member-5")
+	assert.True(t, proto.Equal(expected, member))
+}
+
+func randomMember(id string) fuddle.Member {
+	if id == "" {
+		id = uuid.New().String()
+	}
+	return fuddle.Member{
+		ID:       id,
+		Service:  uuid.New().String(),
+		Locality: uuid.New().String(),
+		Created:  rand.Int63(),
+		Revision: uuid.New().String(),
+		Metadata: map[string]string{
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+		},
+	}
+}
+
+func sortMembers(m []fuddle.Member) {
+	sort.Slice(m, func(i, j int) bool {
+		return m[i].ID < m[j].ID
+	})
+}
+
+func waitForMembers(ctx context.Context, client *fuddle.Fuddle, count int) error {
+	found := false
+	recvCh := make(chan interface{})
+	unsubscribe := client.Subscribe(func() {
+		if found {
+			return
+		}
+
+		if len(client.Members()) == count {
+			found = true
+			close(recvCh)
+			return
+		}
+	})
+	defer unsubscribe()
+
+	if err := waitWithContext(ctx, recvCh); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitWithContext(ctx context.Context, ch chan interface{}) error {
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func fromRPC(m *rpc.Member) fuddle.Member {
+	return fuddle.Member{
+		ID:       m.Id,
+		Service:  m.Service,
+		Locality: m.Locality,
+		Created:  m.Created,
+		Revision: m.Revision,
+		Metadata: m.Metadata,
+	}
+}


### PR DESCRIPTION
# Description
Adds a `fuddle info` command to inspect the registered members in the cluster.

## Testing
New RPC APIs have integration tests. The CLI changes tested manually.

## Docs
The new CLI command is self documenting in the fuddle CLI.
