### PR TITLE
add registry metrics

### DIFF
--- a/pkg/fuddle/fuddle.go
+++ b/pkg/fuddle/fuddle.go
@@ -42,6 +42,8 @@ func NewFuddle(conf *config.Config, opts ...Option) (*Fuddle, error) {
 
 	logger.Info("starting fuddle", zap.Object("conf", conf))
 
+	collector := metrics.NewPromCollector()
+
 	r := registry.NewRegistry(
 		conf.NodeID,
 		registry.WithRegistryLocalMember(&rpc.Member{
@@ -50,15 +52,14 @@ func NewFuddle(conf *config.Config, opts ...Option) (*Fuddle, error) {
 			Created:  time.Now().UnixMilli(),
 			Revision: "unknown",
 		}),
-		registry.WithRegistryLogger(
-			logger.With(zap.String("stream", "registry")),
-		),
 		registry.WithHeartbeatTimeout(conf.Registry.HeartbeatTimeout.Milliseconds()),
 		registry.WithReconnectTimeout(conf.Registry.ReconnectTimeout.Milliseconds()),
 		registry.WithTombstoneTimeout(conf.Registry.TombstoneTimeout.Milliseconds()),
+		registry.WithCollector(collector),
+		registry.WithRegistryLogger(
+			logger.With(zap.String("stream", "registry")),
+		),
 	)
-
-	collector := metrics.NewPromCollector()
 
 	c := cluster.NewCluster(
 		r,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,7 +41,29 @@ func NewGauge(subsystem string, name string, labels []string, help string) *Gaug
 	}
 }
 
+func (g *Gauge) Inc(labels map[string]string) {
+	labelsToLowercase(labels)
+
+	g.mu.Lock()
+	g.values[labelsToString(labels)] = g.values[labelsToString(labels)] + 1
+	g.mu.Unlock()
+
+	g.promGauge.With(prometheus.Labels(labels)).Inc()
+}
+
+func (g *Gauge) Dec(labels map[string]string) {
+	labelsToLowercase(labels)
+
+	g.mu.Lock()
+	g.values[labelsToString(labels)] = g.values[labelsToString(labels)] - 1
+	g.mu.Unlock()
+
+	g.promGauge.With(prometheus.Labels(labels)).Dec()
+}
+
 func (g *Gauge) Set(v float64, labels map[string]string) {
+	labelsToLowercase(labels)
+
 	g.mu.Lock()
 	g.values[labelsToString(labels)] = v
 	g.mu.Unlock()
@@ -73,4 +95,10 @@ func labelsToString(labels map[string]string) string {
 		strs = append(strs, lv.String())
 	}
 	return strings.Join(strs, ",")
+}
+
+func labelsToLowercase(labels map[string]string) {
+	for k, v := range labels {
+		labels[k] = strings.ToLower(v)
+	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,6 +19,26 @@ func TestGauge(t *testing.T) {
 		"b": "9",
 		"c": "10",
 	})
+	gauge.Inc(map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	})
+	gauge.Inc(map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	})
+	gauge.Inc(map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	})
+	gauge.Dec(map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	})
 
 	assert.Equal(t, 3.0, gauge.Value(map[string]string{
 		"a": "8",
@@ -30,10 +50,14 @@ func TestGauge(t *testing.T) {
 		"b": "2",
 		"c": "3",
 	}))
+	assert.Equal(t, 2.0, gauge.Value(map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}))
 	assert.Equal(t, 0.0, gauge.Value(map[string]string{
 		"a": "99",
 		"b": "2",
 		"c": "3",
 	}))
-
 }

--- a/pkg/registry/metrics.go
+++ b/pkg/registry/metrics.go
@@ -13,7 +13,7 @@ func NewMetrics() *Metrics {
 		MembersCount: metrics.NewGauge(
 			"registry",
 			"members.count",
-			[]string{"status"},
+			[]string{"status", "owner"},
 			"Number of registered members in the cluster",
 		),
 	}

--- a/pkg/registry/metrics.go
+++ b/pkg/registry/metrics.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"github.com/fuddle-io/fuddle/pkg/metrics"
+)
+
+type Metrics struct {
+	MembersCount *metrics.Gauge
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		MembersCount: metrics.NewGauge(
+			"registry",
+			"members.count",
+			[]string{"status"},
+			"Number of registered members in the cluster",
+		),
+	}
+}
+
+func (m *Metrics) Register(collector metrics.Collector) {
+	collector.AddGauge(m.MembersCount)
+}

--- a/pkg/registry/options.go
+++ b/pkg/registry/options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -13,6 +14,7 @@ type registryOptions struct {
 	reconnectTimeout int64
 	tombstoneTimeout int64
 	now              int64
+	collector        metrics.Collector
 	logger           *zap.Logger
 }
 
@@ -22,6 +24,7 @@ func defaultRegistryOptions() *registryOptions {
 		reconnectTimeout: 5 * 60 * 1000,
 		tombstoneTimeout: 30 * 60 * 1000,
 		now:              time.Now().UnixMilli(),
+		collector:        nil,
 		logger:           zap.NewNop(),
 	}
 }
@@ -90,6 +93,18 @@ func (o registryNowTimeOption) apply(opts *registryOptions) {
 // useful for testing.
 func WithRegistryNowTime(now int64) Option {
 	return registryNowTimeOption{now: now}
+}
+
+type collectorOption struct {
+	collector metrics.Collector
+}
+
+func (o collectorOption) apply(opts *registryOptions) {
+	opts.collector = o.collector
+}
+
+func WithCollector(c metrics.Collector) Option {
+	return collectorOption{collector: c}
 }
 
 type loggerRegistryOption struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -627,6 +627,7 @@ func (r *Registry) setMemberLocked(m *VersionedMember) {
 	if existing, ok := r.members[m.Member.Id]; ok {
 		r.metrics.MembersCount.Dec(map[string]string{
 			"status": existing.Member.Status.String(),
+			"owner":  existing.Version.Owner,
 		})
 	}
 
@@ -634,6 +635,7 @@ func (r *Registry) setMemberLocked(m *VersionedMember) {
 
 	r.metrics.MembersCount.Inc(map[string]string{
 		"status": m.Member.Status.String(),
+		"owner":  m.Version.Owner,
 	})
 }
 
@@ -641,6 +643,7 @@ func (r *Registry) deleteMemberLocked(id string) {
 	if existing, ok := r.members[id]; ok {
 		r.metrics.MembersCount.Dec(map[string]string{
 			"status": existing.Member.Status.String(),
+			"owner":  existing.Version.Owner,
 		})
 	}
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -56,13 +56,19 @@ type Registry struct {
 	reconnectTimeout int64
 	tombstoneTimeout int64
 
-	logger *zap.Logger
+	logger  *zap.Logger
+	metrics *Metrics
 }
 
 func NewRegistry(localID string, opts ...Option) *Registry {
 	options := defaultRegistryOptions()
 	for _, o := range opts {
 		o.apply(options)
+	}
+
+	metrics := NewMetrics()
+	if options.collector != nil {
+		metrics.Register(options.collector)
 	}
 
 	reg := &Registry{
@@ -73,18 +79,17 @@ func NewRegistry(localID string, opts ...Option) *Registry {
 		heartbeatTimeout: options.heartbeatTimeout,
 		reconnectTimeout: options.reconnectTimeout,
 		tombstoneTimeout: options.tombstoneTimeout,
+		metrics:          metrics,
 		logger:           options.logger,
 	}
 
 	if options.localMember != nil {
-		member := options.localMember
-		member.Status = rpc.MemberStatus_UP
-
+		member := memberWithStatus(options.localMember, rpc.MemberStatus_UP)
 		versionedMember := &VersionedMember{
-			Member:  options.localMember,
+			Member:  member,
 			Version: reg.nextVersionLocked(options.now),
 		}
-		reg.members[localID] = versionedMember
+		reg.setMemberLocked(versionedMember)
 
 		reg.logger.Info(
 			"added local member",
@@ -130,6 +135,10 @@ func (r *Registry) UpMembers() []*VersionedMember {
 		}
 	}
 	return members
+}
+
+func (r *Registry) Metrics() *Metrics {
+	return r.metrics
 }
 
 // Subscribe to member updates.
@@ -213,8 +222,7 @@ func (r *Registry) AddMember(member *rpc.Member, opts ...Option) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	member.Status = rpc.MemberStatus_UP
-	r.updateMemberLocked(member, opts...)
+	r.updateMemberLocked(memberWithStatus(member, rpc.MemberStatus_UP), opts...)
 }
 
 // RemoveMember removes the member with the given ID.
@@ -233,8 +241,7 @@ func (r *Registry) RemoveMember(id string, opts ...Option) {
 	}
 
 	member := m.Member
-	member.Status = rpc.MemberStatus_LEFT
-	r.updateMemberLocked(member, opts...)
+	r.updateMemberLocked(memberWithStatus(member, rpc.MemberStatus_LEFT), opts...)
 }
 
 // RemoteUpdate applies an updates received from another node.
@@ -277,10 +284,10 @@ func (r *Registry) RemoteUpdate(update *rpc.RemoteMemberUpdate) {
 		}
 	}
 
-	r.members[update.Member.Id] = &VersionedMember{
+	r.setMemberLocked(&VersionedMember{
 		Member:  update.Member,
 		Version: update.Version,
-	}
+	})
 
 	r.logger.Info(
 		"updated member; remote",
@@ -348,7 +355,7 @@ func (r *Registry) updateMemberLocked(member *rpc.Member, opts ...Option) {
 		Member:  member,
 		Version: version,
 	}
-	r.members[member.Id] = versionedMember
+	r.setMemberLocked(versionedMember)
 
 	r.logger.Info(
 		"updated member; owner",
@@ -391,8 +398,7 @@ func (r *Registry) checkOwnedMemberLivenessLocked(id string, opts ...Option) {
 				"removing left member",
 				zap.Int64("last-update", options.now-m.Version.Timestamp),
 			)
-			m.Member.Status = rpc.MemberStatus_LEFT
-			delete(r.members, m.Member.Id)
+			r.deleteMemberLocked(m.Member.Id)
 		}
 	}
 
@@ -402,8 +408,9 @@ func (r *Registry) checkOwnedMemberLivenessLocked(id string, opts ...Option) {
 				"member removed after missing heartbeats",
 				zap.Int64("last-update", options.now-m.Version.Timestamp),
 			)
-			m.Member.Status = rpc.MemberStatus_LEFT
-			r.updateMemberLocked(m.Member, opts...)
+			r.updateMemberLocked(
+				memberWithStatus(m.Member, rpc.MemberStatus_LEFT), opts...,
+			)
 		}
 	}
 
@@ -415,8 +422,9 @@ func (r *Registry) checkOwnedMemberLivenessLocked(id string, opts ...Option) {
 				"member down after missing heartbeats",
 				zap.Int64("last-update", options.now-m.Version.Timestamp),
 			)
-			m.Member.Status = rpc.MemberStatus_DOWN
-			r.updateMemberLocked(m.Member, opts...)
+			r.updateMemberLocked(
+				memberWithStatus(m.Member, rpc.MemberStatus_DOWN), opts...,
+			)
 		}
 	}
 }
@@ -442,10 +450,13 @@ func (r *Registry) checkRemoteMemberLivenessLocked(id string, opts ...Option) {
 		// If the member is up, mark it down as it has missed the heartbeat
 		// timeout.
 		if m.Member.Status == rpc.MemberStatus_UP {
-			m.Member.Status = rpc.MemberStatus_DOWN
+			r.updateMemberLocked(
+				memberWithStatus(m.Member, rpc.MemberStatus_DOWN),
+				opts...,
+			)
+		} else {
+			r.updateMemberLocked(m.Member, opts...)
 		}
-
-		r.updateMemberLocked(m.Member, opts...)
 	}
 }
 
@@ -612,6 +623,30 @@ func (r *Registry) allUpdatesLocked(knownMembers map[string]*rpc.Version) []*rpc
 	return updates
 }
 
+func (r *Registry) setMemberLocked(m *VersionedMember) {
+	if existing, ok := r.members[m.Member.Id]; ok {
+		r.metrics.MembersCount.Dec(map[string]string{
+			"status": existing.Member.Status.String(),
+		})
+	}
+
+	r.members[m.Member.Id] = m
+
+	r.metrics.MembersCount.Inc(map[string]string{
+		"status": m.Member.Status.String(),
+	})
+}
+
+func (r *Registry) deleteMemberLocked(id string) {
+	if existing, ok := r.members[id]; ok {
+		r.metrics.MembersCount.Dec(map[string]string{
+			"status": existing.Member.Status.String(),
+		})
+	}
+
+	delete(r.members, id)
+}
+
 // compareVersions compares lhs and rhs.
 //
 // If the owners don't match but the timestamps do, lhs is considered greater.
@@ -642,6 +677,12 @@ func compareVersions(lhs *rpc.Version, rhs *rpc.Version) int {
 		return -1
 	}
 	return 0
+}
+
+func memberWithStatus(m *rpc.Member, status rpc.MemberStatus) *rpc.Member {
+	cp := copyMember(m)
+	cp.Status = status
+	return cp
 }
 
 func copyMember(m *rpc.Member) *rpc.Member {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -25,6 +25,7 @@ func TestRegistry_AddLocalMember(t *testing.T) {
 
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 }
 
@@ -61,6 +62,7 @@ func TestRegistry_AddMember(t *testing.T) {
 
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 }
 
@@ -122,6 +124,7 @@ func TestRegistry_RemoveMember(t *testing.T) {
 
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "left",
+		"owner":  "local",
 	}))
 }
 
@@ -180,6 +183,11 @@ func TestRegistry_RemoteUpdateTakeOwnership(t *testing.T) {
 	addedMember := randomMember("my-member")
 	reg.AddMember(addedMember, WithRegistryNowTime(100))
 
+	assert.Equal(t, 2.0, reg.Metrics().MembersCount.Value(map[string]string{
+		"status": "up",
+		"owner":  "local",
+	}))
+
 	updatedMember := randomMember("my-member")
 	reg.RemoteUpdate(&rpc.RemoteMemberUpdate{
 		Member: updatedMember,
@@ -194,6 +202,15 @@ func TestRegistry_RemoteUpdateTakeOwnership(t *testing.T) {
 	m, ok := reg.Member("my-member")
 	assert.True(t, ok)
 	assert.True(t, proto.Equal(updatedMember, m))
+
+	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
+		"status": "up",
+		"owner":  "local",
+	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
+		"status": "up",
+		"owner":  "remote",
+	}))
 }
 
 func TestRegistry_RemoteUpdateWithOutdatedVersionIgnored(t *testing.T) {
@@ -411,9 +428,11 @@ func TestRegistry_MarkMemberDownAfterMissingHeartbeats(t *testing.T) {
 
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "down",
+		"owner":  "local",
 	}))
 
 	// Adding the member again should revive it.
@@ -425,9 +444,11 @@ func TestRegistry_MarkMemberDownAfterMissingHeartbeats(t *testing.T) {
 
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "down",
+		"owner":  "local",
 	}))
 }
 
@@ -460,9 +481,11 @@ func TestRegistry_MarkMemberRemovedAfterMissingHeartbeats(t *testing.T) {
 
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "left",
+		"owner":  "local",
 	}))
 
 	m, ok = reg.Member("my-member")
@@ -478,9 +501,11 @@ func TestRegistry_MarkMemberRemovedAfterMissingHeartbeats(t *testing.T) {
 
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "left",
+		"owner":  "local",
 	}))
 }
 
@@ -504,12 +529,15 @@ func TestRegistry_MarkMemberLeftMemberRemovedAfterTombstoneTimeout(t *testing.T)
 
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "down",
+		"owner":  "local",
 	}))
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "left",
+		"owner":  "local",
 	}))
 }
 


### PR DESCRIPTION
# Description
Adds a `fuddle_registry_members_count` metric that contains the number of members in the registry, with labels for member status (up, down, left) and owner