### PR TITLE
add members owned metric

### DIFF
--- a/pkg/fcm/cluster/cluster.go
+++ b/pkg/fcm/cluster/cluster.go
@@ -27,7 +27,6 @@ type Cluster struct {
 	id          string
 	fuddleNodes map[*FuddleNode]interface{}
 	memberNodes map[*MemberNode]interface{}
-	seeds       []string
 
 	logDir string
 }
@@ -89,6 +88,14 @@ func (c *Cluster) RPCAddrs() []string {
 	var addrs []string
 	for n := range c.fuddleNodes {
 		addrs = append(addrs, fmt.Sprintf("127.0.0.1:%d", n.Fuddle.Config.RPC.AdvPort))
+	}
+	return addrs
+}
+
+func (c *Cluster) GossipAddrs() []string {
+	var addrs []string
+	for n := range c.fuddleNodes {
+		addrs = append(addrs, fmt.Sprintf("127.0.0.1:%d", n.Fuddle.Config.Gossip.AdvPort))
 	}
 	return addrs
 }
@@ -155,7 +162,7 @@ func (c *Cluster) AddFuddleNode() (*FuddleNode, error) {
 	conf.Gossip.AdvAddr = "127.0.0.1"
 	conf.Gossip.BindPort = gossipPort
 	conf.Gossip.AdvPort = gossipPort
-	conf.Gossip.Seeds = c.seeds
+	conf.Gossip.Seeds = c.GossipAddrs()
 
 	f, err := fuddle.NewFuddle(
 		conf,
@@ -175,7 +182,6 @@ func (c *Cluster) AddFuddleNode() (*FuddleNode, error) {
 	}
 
 	c.fuddleNodes[node] = struct{}{}
-	c.seeds = append(c.seeds, fmt.Sprintf("127.0.0.1:%d", gossipPort))
 
 	return node, nil
 }

--- a/pkg/registry/metrics.go
+++ b/pkg/registry/metrics.go
@@ -6,6 +6,7 @@ import (
 
 type Metrics struct {
 	MembersCount *metrics.Gauge
+	MembersOwned *metrics.Gauge
 }
 
 func NewMetrics() *Metrics {
@@ -16,9 +17,16 @@ func NewMetrics() *Metrics {
 			[]string{"status", "owner"},
 			"Number of registered members in the cluster",
 		),
+		MembersOwned: metrics.NewGauge(
+			"registry",
+			"members.owned",
+			[]string{"status"},
+			"Number of members owned by this node",
+		),
 	}
 }
 
 func (m *Metrics) Register(collector metrics.Collector) {
 	collector.AddGauge(m.MembersCount)
+	collector.AddGauge(m.MembersOwned)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -629,6 +629,11 @@ func (r *Registry) setMemberLocked(m *VersionedMember) {
 			"status": existing.Member.Status.String(),
 			"owner":  existing.Version.Owner,
 		})
+		if existing.Version.Owner == r.localID {
+			r.metrics.MembersOwned.Dec(map[string]string{
+				"status": existing.Member.Status.String(),
+			})
+		}
 	}
 
 	r.members[m.Member.Id] = m
@@ -637,6 +642,11 @@ func (r *Registry) setMemberLocked(m *VersionedMember) {
 		"status": m.Member.Status.String(),
 		"owner":  m.Version.Owner,
 	})
+	if m.Version.Owner == r.localID {
+		r.metrics.MembersOwned.Inc(map[string]string{
+			"status": m.Member.Status.String(),
+		})
+	}
 }
 
 func (r *Registry) deleteMemberLocked(id string) {
@@ -645,6 +655,12 @@ func (r *Registry) deleteMemberLocked(id string) {
 			"status": existing.Member.Status.String(),
 			"owner":  existing.Version.Owner,
 		})
+
+		if existing.Version.Owner == r.localID {
+			r.metrics.MembersOwned.Dec(map[string]string{
+				"status": existing.Member.Status.String(),
+			})
+		}
 	}
 
 	delete(r.members, id)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -27,6 +27,9 @@ func TestRegistry_AddLocalMember(t *testing.T) {
 		"status": "up",
 		"owner":  "local",
 	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "up",
+	}))
 }
 
 func TestRegistry_LocalMemberUpdateIgnored(t *testing.T) {
@@ -63,6 +66,9 @@ func TestRegistry_AddMember(t *testing.T) {
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
 		"owner":  "local",
+	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "up",
 	}))
 }
 
@@ -126,6 +132,9 @@ func TestRegistry_RemoveMember(t *testing.T) {
 		"status": "left",
 		"owner":  "local",
 	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "left",
+	}))
 }
 
 func TestRegistry_RemoveMemberDiscardOutdated(t *testing.T) {
@@ -187,6 +196,9 @@ func TestRegistry_RemoteUpdateTakeOwnership(t *testing.T) {
 		"status": "up",
 		"owner":  "local",
 	}))
+	assert.Equal(t, 2.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "up",
+	}))
 
 	updatedMember := randomMember("my-member")
 	reg.RemoteUpdate(&rpc.RemoteMemberUpdate{
@@ -210,6 +222,9 @@ func TestRegistry_RemoteUpdateTakeOwnership(t *testing.T) {
 	assert.Equal(t, 1.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "up",
 		"owner":  "remote",
+	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "up",
 	}))
 }
 
@@ -434,6 +449,9 @@ func TestRegistry_MarkMemberDownAfterMissingHeartbeats(t *testing.T) {
 		"status": "down",
 		"owner":  "local",
 	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "down",
+	}))
 
 	// Adding the member again should revive it.
 	reg.AddMember(addedMember, WithRegistryNowTime(600))
@@ -449,6 +467,9 @@ func TestRegistry_MarkMemberDownAfterMissingHeartbeats(t *testing.T) {
 	assert.Equal(t, 0.0, reg.Metrics().MembersCount.Value(map[string]string{
 		"status": "down",
 		"owner":  "local",
+	}))
+	assert.Equal(t, 1.0, reg.Metrics().MembersOwned.Value(map[string]string{
+		"status": "up",
 	}))
 }
 


### PR DESCRIPTION
Adds a 'members owned' metric containing the number of members the local instance is the owner of.