### PR TITLE
remove redundant updates

### DIFF
--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -453,8 +453,8 @@ func TestRegistry_MarkMemberDownAfterMissingHeartbeats(t *testing.T) {
 		"status": "down",
 	}))
 
-	// Adding the member again should revive it.
-	reg.AddMember(addedMember, WithNowTime(600))
+	// A heartbeat should revive it.
+	reg.MemberHeartbeat(addedMember, WithNowTime(600))
 
 	m, ok = reg.Member("my-member")
 	assert.True(t, ok)
@@ -514,7 +514,7 @@ func TestRegistry_MarkMemberRemovedAfterMissingHeartbeats(t *testing.T) {
 	assert.True(t, proto.Equal(expectedMember, m))
 
 	// Adding the member again should revive it.
-	reg.AddMember(addedMember, WithNowTime(2000))
+	reg.MemberHeartbeat(addedMember, WithNowTime(2000))
 
 	m, ok = reg.Member("my-member")
 	assert.True(t, ok)

--- a/pkg/registry/server/clientwriteregistry.go
+++ b/pkg/registry/server/clientwriteregistry.go
@@ -76,7 +76,7 @@ func (s *ClientWriteRegistryServer) Register(stream rpc.ClientWriteRegistry_Regi
 		}
 
 		if m.UpdateType == rpc.ClientUpdateType_CLIENT_HEARTBEAT {
-			s.registry.AddMember(member)
+			s.registry.MemberHeartbeat(member)
 		}
 
 		if m.UpdateType == rpc.ClientUpdateType_CLIENT_UNREGISTER {


### PR DESCRIPTION
# Description
Removes redundant heartbeats, by only forwarding heartbeats when the owner has changed.
