### PR TITLE
remove registry v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-	github.com/fuddle-io/fuddle-go v0.0.0-20230415052753-924720f690ec
-	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230421171436-00bc196b1a37
+	github.com/fuddle-io/fuddle-go v0.0.0-20230422084743-e49982a84fd4
+	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422081012-c9264d5343e3
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-sockaddr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -63,12 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fuddle-io/fuddle-go v0.0.0-20230415052753-924720f690ec h1:MWMKeTMC/271U1MVfcbSB2+HLqJp+hi6XaQPtrvZYcw=
-github.com/fuddle-io/fuddle-go v0.0.0-20230415052753-924720f690ec/go.mod h1:zgz5bJDTIaiIh+4QpfTcbBDrTfgTONr+iAsr3OdMIN8=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230419074357-7a278340f176 h1:yWssl5QvyKagsY3Be4m8fapcrnjdgHJXZP0b8BcWTcM=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230419074357-7a278340f176/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230421171436-00bc196b1a37 h1:MC3c0yXgLoP+lD7fkmAUo+++zMNq8Bm06z3Dwx5XqGI=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230421171436-00bc196b1a37/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
+github.com/fuddle-io/fuddle-go v0.0.0-20230422084743-e49982a84fd4 h1:qdur/aSKrv5oSkYIXfyv0yiOnh/usEwfq2ax5BDW03s=
+github.com/fuddle-io/fuddle-go v0.0.0-20230422084743-e49982a84fd4/go.mod h1:bDDTV4lNE2AHxg35fOptkr/7KxbFxbN8EMZrp284tBk=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422081012-c9264d5343e3 h1:3D2LUCR22k+1JnnGaDl/cQjt/bbqxsZ3vSGphyiiMTs=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422081012-c9264d5343e3/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -7,15 +7,12 @@ import (
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
 	adminServer "github.com/fuddle-io/fuddle/pkg/admin/server"
 	"github.com/fuddle-io/fuddle/pkg/cluster"
-	clusterv2 "github.com/fuddle-io/fuddle/pkg/clusterv2"
 	"github.com/fuddle-io/fuddle/pkg/config"
 	"github.com/fuddle-io/fuddle/pkg/gossip"
 	"github.com/fuddle-io/fuddle/pkg/logger"
 	"github.com/fuddle-io/fuddle/pkg/metrics"
 	"github.com/fuddle-io/fuddle/pkg/registry"
 	registryServer "github.com/fuddle-io/fuddle/pkg/registry/server"
-	registryv2 "github.com/fuddle-io/fuddle/pkg/registryv2/registry"
-	registryServerv2 "github.com/fuddle-io/fuddle/pkg/registryv2/server"
 	rpcServer "github.com/fuddle-io/fuddle/pkg/server"
 	"go.uber.org/zap"
 )
@@ -26,8 +23,6 @@ type Node struct {
 
 	gossip      *gossip.Gossip
 	registry    *registry.Registry
-	registryv2  *registryv2.Registry
-	clusterv2   *clusterv2.Cluster
 	rpcServer   *rpcServer.Server
 	adminServer *adminServer.Server
 
@@ -71,14 +66,11 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 		registry.WithLogger(logger.Logger("registry")),
 	)
 
-	regv2 := registryv2.NewRegistry(conf.NodeID, time.Now().UnixMilli())
-
 	c := cluster.NewCluster(
 		r,
 		cluster.WithLogger(logger.Logger("cluster")),
 		cluster.WithCollector(collector),
 	)
-	clusterv2 := clusterv2.NewCluster(regv2)
 
 	var adminServerOpts []adminServer.Option
 	if options.adminListener != nil {
@@ -105,12 +97,11 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 	gossipOpts = append(gossipOpts, gossip.WithOnJoin(func(node gossip.Node) {
 		if node.ID != conf.NodeID {
 			c.OnJoin(node.ID, node.RPCAddr)
-			clusterv2.OnJoin(node.ID, node.RPCAddr)
 		}
 	}))
 	gossipOpts = append(gossipOpts, gossip.WithOnLeave(func(node gossip.Node) {
 		if node.ID != conf.NodeID {
-			clusterv2.OnLeave(node.ID)
+			c.OnLeave(node.ID)
 		}
 	}))
 	gossipOpts = append(gossipOpts, gossip.WithLogger(logger.Logger("gossip")))
@@ -146,13 +137,6 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 	rpc.RegisterClientWriteRegistryServer(s.GRPCServer(), clientWriteRegistryServer)
 	rpc.RegisterReplicaReadRegistryServer(s.GRPCServer(), replicaReadRegistryServer)
 
-	clientReadRegistryServerv2 := registryServerv2.NewClientReadServer()
-	clientWriteRegistryServerv2 := registryServerv2.NewClientWriteServer()
-	replicaRegistryServer := registryServerv2.NewReplicaServer()
-	rpc.RegisterClientReadRegistry2Server(s.GRPCServer(), clientReadRegistryServerv2)
-	rpc.RegisterClientWriteRegistry2Server(s.GRPCServer(), clientWriteRegistryServerv2)
-	rpc.RegisterReplicaRegistry2Server(s.GRPCServer(), replicaRegistryServer)
-
 	if err := s.Serve(); err != nil {
 		return nil, fmt.Errorf("fuddle: %w", err)
 	}
@@ -160,8 +144,6 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 	n := &Node{
 		Config:      conf,
 		registry:    r,
-		registryv2:  regv2,
-		clusterv2:   clusterv2,
 		gossip:      g,
 		rpcServer:   s,
 		adminServer: adminServer,
@@ -170,7 +152,6 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 	}
 
 	go n.failureDetector()
-	go n.replicaRepair()
 
 	return n, nil
 }
@@ -203,20 +184,6 @@ func (n *Node) failureDetector() {
 			return
 		case <-ticker.C:
 			n.registry.CheckMembersLiveness()
-		}
-	}
-}
-
-func (n *Node) replicaRepair() {
-	ticker := time.NewTicker(time.Millisecond * 500)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-n.done:
-			return
-		case <-ticker.C:
-			n.clusterv2.ReplicaRepair()
 		}
 	}
 }

--- a/pkg/registry/client/client.go
+++ b/pkg/registry/client/client.go
@@ -129,7 +129,7 @@ func (c *Client) onDisconnected() {
 	}
 }
 
-func (c *Client) streamUpdates(stream rpc.Registry_SubscribeClient) {
+func (c *Client) streamUpdates(stream rpc.ReplicaReadRegistry_UpdatesClient) {
 	for {
 		update, err := stream.Recv()
 		if err != nil {


### PR DESCRIPTION
Removes registryv2 from `Node`, as will pull v2 into the current registry instead of a complete rewrite.