### PR TITLE
registry: add replicaserver v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 	github.com/fuddle-io/fuddle-go v0.0.0-20230422141443-eba05f3b16f3
-	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422185040-8bc46889ab4a
+	github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230423082845-3c0e4ed6d445
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-sockaddr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fuddle-io/fuddle-go v0.0.0-20230422141443-eba05f3b16f3 h1:lvs9JnbE9zhFq44JW1CWoUlBtul6ULlO7ihIZO9O+5M=
 github.com/fuddle-io/fuddle-go v0.0.0-20230422141443-eba05f3b16f3/go.mod h1:8H8xZn1+dQF7m/cxUeJ63xVGTtlLD+aMaBSmXSMmo2w=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422185040-8bc46889ab4a h1:w9O2nJyPycPK0XXsXL3JcpeLsypxmsDG56iMyMCm75U=
-github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230422185040-8bc46889ab4a/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230423082845-3c0e4ed6d445 h1:7tkFB5XinAjsc4VTGlhQghp5lD5aTCUn98WDwqad5oo=
+github.com/fuddle-io/fuddle-rpc/go v0.0.0-20230423082845-3c0e4ed6d445/go.mod h1:plrExYS7pCDF4Np8fz1W+Rcc+KYY6DlqRAMmu9Qr4sA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ func (c *Cluster) OnJoin(id string, addr string) {
 	)
 
 	client, err := registryClient.ReplicaConnect(
-		addr, registryClient.WithLogger(c.logger),
+		addr, c.registry.LocalID(), registryClient.WithLogger(c.logger),
 	)
 	if err != nil {
 		c.logger.Error("client connect", zap.Error(err))

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ func (c *Cluster) OnJoin(id string, addr string) {
 	)
 
 	client, err := registryClient.ReplicaConnect(
-		addr, c.registry, registryClient.WithLogger(c.logger),
+		addr, registryClient.WithLogger(c.logger),
 	)
 	if err != nil {
 		c.logger.Error("client connect", zap.Error(err))

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -140,7 +140,7 @@ func NewNode(conf *config.Config, opts ...Option) (*Node, error) {
 	)
 	rpc.RegisterClientReadRegistryServer(s.GRPCServer(), clientReadServer)
 	rpc.RegisterClientWriteRegistryServer(s.GRPCServer(), clientWriteServer)
-	rpc.RegisterReplicaReadRegistryServer(s.GRPCServer(), replicaReadServer)
+	rpc.RegisterReplicaRegistry2Server(s.GRPCServer(), replicaReadServer)
 
 	if err := s.Serve(); err != nil {
 		return nil, fmt.Errorf("fuddle: %w", err)

--- a/pkg/registry/client/options.go
+++ b/pkg/registry/client/options.go
@@ -1,16 +1,22 @@
 package client
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 )
 
 type options struct {
-	logger *zap.Logger
+	pendingUpdatesLimit int
+	updateTimeout       time.Duration
+	logger              *zap.Logger
 }
 
 func defaultOptions() *options {
 	return &options{
-		logger: zap.NewNop(),
+		pendingUpdatesLimit: 128,
+		updateTimeout:       time.Second * 20,
+		logger:              zap.NewNop(),
 	}
 }
 
@@ -18,14 +24,38 @@ type Option interface {
 	apply(*options)
 }
 
+type pendingUpdatesLimitOption struct {
+	limit int
+}
+
+func (o pendingUpdatesLimitOption) apply(opts *options) {
+	opts.pendingUpdatesLimit = o.limit
+}
+
+func WithPendingUpdatesLimit(limit int) Option {
+	return pendingUpdatesLimitOption{limit: limit}
+}
+
+type updateTimeoutOption struct {
+	timeout time.Duration
+}
+
+func (o updateTimeoutOption) apply(opts *options) {
+	opts.updateTimeout = o.timeout
+}
+
+func WithUpdateTimeoutOption(timeout time.Duration) Option {
+	return updateTimeoutOption{timeout: timeout}
+}
+
 type loggerOption struct {
-	Log *zap.Logger
+	log *zap.Logger
 }
 
 func (o loggerOption) apply(opts *options) {
-	opts.logger = o.Log
+	opts.logger = o.log
 }
 
 func WithLogger(log *zap.Logger) Option {
-	return loggerOption{Log: log}
+	return loggerOption{log: log}
 }

--- a/pkg/registry/client/replicaclient.go
+++ b/pkg/registry/client/replicaclient.go
@@ -7,10 +7,160 @@ import (
 	"time"
 
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+type ReplicaClientMetrics struct {
+	ReplicaUpdatesOutbound *metrics.Counter
+}
+
+func NewReplicaClientMetrics() *ReplicaClientMetrics {
+	return &ReplicaClientMetrics{
+		ReplicaUpdatesOutbound: metrics.NewCounter(
+			"registry",
+			"replica.updates.outbound",
+			[]string{"target", "status"},
+			"Number of outbound updates send to a replica",
+		),
+	}
+}
+
+func (m *ReplicaClientMetrics) Register(collector metrics.Collector) {
+	collector.AddCounter(m.ReplicaUpdatesOutbound)
+}
+
+// ReplicaClient is used to make RPCs to other Fuddle nodes in the cluster.
+//
+// If the connection to the replica drops, the client will keep trying to
+// reconnect until it is closed.
+type ReplicaClient struct {
+	targetID string
+	localID  string
+
+	pending *pendingUpdates
+
+	updateTimeout time.Duration
+
+	conn   *grpc.ClientConn
+	client rpc.ReplicaRegistry2Client
+
+	ctx    context.Context
+	cancel func()
+
+	wg sync.WaitGroup
+
+	metrics *ReplicaClientMetrics
+	logger  *zap.Logger
+}
+
+func ReplicaConnect(addr string, targetID string, localID string, metrics *ReplicaClientMetrics, opts ...Option) (*ReplicaClient, error) {
+	options := defaultOptions()
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	var retryPolicy = `{
+		"methodConfig": [{
+			"name": [{"service": "registry.ReplicaRegistry2", "method": "Update"}],
+			"waitForReady": true,
+
+			"retryPolicy": {
+				"MaxAttempts": 5,
+				"InitialBackoff": ".2s",
+				"MaxBackoff": "10s",
+				"BackoffMultiplier": 2.0,
+				"RetryableStatusCodes": [ "UNAVAILABLE" ]
+			}
+		}]
+	}`
+	// Dial won't connect yet so should never fail.
+	conn, err := grpc.Dial(
+		addr,
+		grpc.WithDefaultServiceConfig(retryPolicy),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("replica client: connect: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &ReplicaClient{
+		targetID:      targetID,
+		localID:       localID,
+		pending:       newPendingUpdates(options.pendingUpdatesLimit),
+		updateTimeout: options.updateTimeout,
+		conn:          conn,
+		client:        rpc.NewReplicaRegistry2Client(conn),
+		ctx:           ctx,
+		cancel:        cancel,
+		metrics:       metrics,
+		logger:        options.logger,
+	}
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.sendLoop()
+	}()
+
+	return c, nil
+}
+
+// Update forwards the given member update to the connected replica.
+//
+// This sends the update in the background to avoid blocking. If the number of
+// pending updates exceeds pendingUpdatesLimit, the older updates are dropped.
+// Therefore if the client cannot connector for a long time, updates may be
+// dropped and have to be repaired by replica repair.
+func (c *ReplicaClient) Update(u *rpc.Member2) {
+	c.pending.Push(u)
+}
+
+func (c *ReplicaClient) Close() {
+	c.cancel()
+	c.pending.Close()
+	c.wg.Wait()
+}
+
+func (c *ReplicaClient) sendLoop() {
+	for {
+		m, ok := c.pending.Take()
+		if !ok {
+			// Client closed.
+			return
+		}
+
+		// Update will keep retrying for until cancelled. If it still does not
+		// succeed, the update will be dropped and the replica will get the
+		// update via read repair when it comes back.
+		ctx, cancel := context.WithTimeout(c.ctx, c.updateTimeout)
+		defer cancel()
+		if _, err := c.client.Update(ctx, &rpc.UpdateRequest{
+			Member:       m,
+			SourceNodeId: c.localID,
+		}); err != nil {
+			c.logger.Warn(
+				"failed to forward update",
+				zap.String("member-id", m.State.Id),
+				zap.String("target", c.targetID),
+				zap.Error(err),
+			)
+
+			c.metrics.ReplicaUpdatesOutbound.Inc(map[string]string{
+				"target": c.targetID,
+				"status": "fail",
+			})
+		} else {
+			c.metrics.ReplicaUpdatesOutbound.Inc(map[string]string{
+				"target": c.targetID,
+				"status": "ok",
+			})
+		}
+	}
+}
 
 type pendingUpdates struct {
 	limit int
@@ -79,119 +229,4 @@ func (p *pendingUpdates) Close() {
 	p.closed = true
 	// Signal the write loop so it closes.
 	p.cv.Signal()
-}
-
-// ReplicaClient is used to make RPCs to other Fuddle nodes in the cluster.
-//
-// If the connection to the replica drops, the client will keep trying to
-// reconnect until it is closed.
-type ReplicaClient struct {
-	localID string
-
-	pending *pendingUpdates
-
-	updateTimeout time.Duration
-
-	conn   *grpc.ClientConn
-	client rpc.ReplicaRegistry2Client
-
-	ctx    context.Context
-	cancel func()
-
-	wg sync.WaitGroup
-
-	logger *zap.Logger
-}
-
-func ReplicaConnect(addr string, localID string, opts ...Option) (*ReplicaClient, error) {
-	options := defaultOptions()
-	for _, o := range opts {
-		o.apply(options)
-	}
-
-	var retryPolicy = `{
-		"methodConfig": [{
-			"name": [{"service": "registry.ReplicaRegistry2", "method": "Update"}],
-			"waitForReady": true,
-
-			"retryPolicy": {
-				"MaxAttempts": 5,
-				"InitialBackoff": ".2s",
-				"MaxBackoff": "10s",
-				"BackoffMultiplier": 2.0,
-				"RetryableStatusCodes": [ "UNAVAILABLE" ]
-			}
-		}]
-	}`
-	// Dial won't connect yet so should never fail.
-	conn, err := grpc.Dial(
-		addr,
-		grpc.WithDefaultServiceConfig(retryPolicy),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("replica client: connect: %w", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := &ReplicaClient{
-		localID:       localID,
-		pending:       newPendingUpdates(options.pendingUpdatesLimit),
-		updateTimeout: options.updateTimeout,
-		conn:          conn,
-		client:        rpc.NewReplicaRegistry2Client(conn),
-		ctx:           ctx,
-		cancel:        cancel,
-		logger:        options.logger,
-	}
-
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-		c.sendLoop()
-	}()
-
-	return c, nil
-}
-
-// Update forwards the given member update to the connected replica.
-//
-// This sends the update in the background to avoid blocking. If the number of
-// pending updates exceeds pendingUpdatesLimit, the older updates are dropped.
-// Therefore if the client cannot connector for a long time, updates may be
-// dropped and have to be repaired by replica repair.
-func (c *ReplicaClient) Update(u *rpc.Member2) {
-	c.pending.Push(u)
-}
-
-func (c *ReplicaClient) Close() {
-	c.cancel()
-	c.pending.Close()
-	c.wg.Wait()
-}
-
-func (c *ReplicaClient) sendLoop() {
-	for {
-		m, ok := c.pending.Take()
-		if !ok {
-			// Client closed.
-			return
-		}
-
-		// Update will keep retrying for until cancelled. If it still does not
-		// succeed, the update will be dropped and the replica will get the
-		// update via read repair when it comes back.
-		ctx, cancel := context.WithTimeout(c.ctx, c.updateTimeout)
-		defer cancel()
-		if _, err := c.client.Update(ctx, &rpc.UpdateRequest{
-			Member:       m,
-			SourceNodeId: c.localID,
-		}); err != nil {
-			c.logger.Warn(
-				"failed to forward update",
-				zap.String("member-id", m.State.Id),
-				zap.Error(err),
-			)
-		}
-	}
 }

--- a/pkg/registry/client/replicaclient.go
+++ b/pkg/registry/client/replicaclient.go
@@ -7,97 +7,187 @@ import (
 	"time"
 
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
-	"github.com/fuddle-io/fuddle/pkg/registry/registry"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-type ReplicaClient struct {
-	addr string
+type pendingUpdates struct {
+	limit int
 
-	registry *registry.Registry
+	pending []*rpc.Member2
+	closed  bool
+
+	cv *sync.Cond
+
+	// mu protects the fields above.
+	mu *sync.Mutex
+}
+
+func newPendingUpdates(limit int) *pendingUpdates {
+	mu := &sync.Mutex{}
+	return &pendingUpdates{
+		limit:  limit,
+		cv:     sync.NewCond(mu),
+		closed: false,
+		mu:     mu,
+	}
+}
+
+func (p *pendingUpdates) Push(u *rpc.Member2) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// If the number of pending items exceeds the limit, drop the older updates.
+	// These updates will dropped updates be repaired by replica repair.
+	if len(p.pending) > p.limit {
+		p.pending = p.pending[1:]
+	}
+
+	if p.closed {
+		return
+	}
+
+	p.pending = append(p.pending, u)
+	p.cv.Signal()
+}
+
+// Take returns the next pending update and removes it, or false if the client
+// is closed.
+func (p *pendingUpdates) Take() (*rpc.Member2, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Since we can miss signals, only block if empty.
+	for len(p.pending) == 0 && !p.closed {
+		p.cv.Wait()
+	}
+
+	if p.closed {
+		return nil, false
+	}
+
+	u := p.pending[0]
+	p.pending = p.pending[1:]
+	return u, true
+}
+
+func (p *pendingUpdates) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	// Signal the write loop so it closes.
+	p.cv.Signal()
+}
+
+// ReplicaClient is used to make RPCs to other Fuddle nodes in the cluster.
+//
+// If the connection to the replica drops, the client will keep trying to
+// reconnect until it is closed.
+type ReplicaClient struct {
+	pending *pendingUpdates
+
+	updateTimeout time.Duration
 
 	conn   *grpc.ClientConn
-	client rpc.ReplicaReadRegistryClient
+	client rpc.ReplicaRegistry2Client
 
-	cancelCtx context.Context
-	cancel    func()
+	ctx    context.Context
+	cancel func()
 
-	pending   []*rpc.Member2
-	pendingMu sync.Mutex
+	wg sync.WaitGroup
 
 	logger *zap.Logger
 }
 
-func ReplicaConnect(addr string, registry *registry.Registry, opts ...Option) (*ReplicaClient, error) {
+func ReplicaConnect(addr string, opts ...Option) (*ReplicaClient, error) {
 	options := defaultOptions()
 	for _, o := range opts {
 		o.apply(options)
 	}
 
-	// Note this won't actually connect to the server so should not fail.
-	conn, err := grpc.DialContext(
-		// Use background context as this isn't actually connecting but just
-		// doing setup.
-		context.Background(),
+	var retryPolicy = `{
+		"methodConfig": [{
+			"name": [{"service": "registry.ReplicaRegistry2", "method": "Update"}],
+			"waitForReady": true,
+
+			"retryPolicy": {
+				"MaxAttempts": 5,
+				"InitialBackoff": ".2s",
+				"MaxBackoff": "10s",
+				"BackoffMultiplier": 2.0,
+				"RetryableStatusCodes": [ "UNAVAILABLE" ]
+			}
+		}]
+	}`
+	// Dial won't connect yet so should never fail.
+	conn, err := grpc.Dial(
 		addr,
+		grpc.WithDefaultServiceConfig(retryPolicy),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("registry client: dial: %w", err)
+		return nil, fmt.Errorf("replica client: connect: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &ReplicaClient{
-		addr:      addr,
-		registry:  registry,
-		conn:      conn,
-		cancelCtx: ctx,
-		cancel:    cancel,
-		client:    rpc.NewReplicaReadRegistryClient(conn),
-		logger:    options.logger,
+		pending:       newPendingUpdates(options.pendingUpdatesLimit),
+		updateTimeout: options.updateTimeout,
+		conn:          conn,
+		client:        rpc.NewReplicaRegistry2Client(conn),
+		ctx:           ctx,
+		cancel:        cancel,
+		logger:        options.logger,
 	}
-	go c.sendLoop()
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.sendLoop()
+	}()
+
 	return c, nil
 }
 
-func (c *ReplicaClient) Update(member *rpc.Member2) {
-	// TODO(AD) this must not block, instead queue up, and if queue gets full
-	// will have to drop messages (which will be fixed by read repair)
-	// TODO(AD) add retries with backoff (order doesn't matter)
-	c.pendingMu.Lock()
-	defer c.pendingMu.Unlock()
-
-	c.pending = append(c.pending, member)
+// Update forwards the given member update to the connected replica.
+//
+// This sends the update in the background to avoid blocking. If the number of
+// pending updates exceeds pendingUpdatesLimit, the older updates are dropped.
+// Therefore if the client cannot connector for a long time, updates may be
+// dropped and have to be repaired by replica repair.
+func (c *ReplicaClient) Update(u *rpc.Member2) {
+	c.pending.Push(u)
 }
 
 func (c *ReplicaClient) Close() {
-	c.logger.Info("closing")
 	c.cancel()
-	c.conn.Close()
+	c.pending.Close()
+	c.wg.Wait()
 }
 
 func (c *ReplicaClient) sendLoop() {
-	// TODO(AD) for now just poll
 	for {
-		select {
-		case <-c.cancelCtx.Done():
+		m, ok := c.pending.Take()
+		if !ok {
+			// Client closed.
 			return
-		case <-time.After(time.Millisecond * 100):
 		}
 
-		c.pendingMu.Lock()
-		pending := c.pending
-		c.pending = nil
-		c.pendingMu.Unlock()
-
-		for _, m := range pending {
-			if _, err := c.client.Update(context.Background(), &rpc.UpdateRequest{
-				Member: m,
-			}); err != nil {
-				c.logger.Warn("failed to send update", zap.Error(err))
-			}
+		// Update will keep retrying for until cancelled. If it still does not
+		// succeed, the update will be dropped and the replica will get the
+		// update via read repair when it comes back.
+		ctx, cancel := context.WithTimeout(c.ctx, c.updateTimeout)
+		defer cancel()
+		if _, err := c.client.Update(ctx, &rpc.UpdateRequest{
+			Member: m,
+		}); err != nil {
+			c.logger.Warn(
+				"failed to forward update",
+				zap.String("member-id", m.State.Id),
+				zap.Error(err),
+			)
 		}
 	}
 }

--- a/pkg/registry/client/replicaclient_integration_test.go
+++ b/pkg/registry/client/replicaclient_integration_test.go
@@ -70,7 +70,9 @@ func TestClient_ForwardUpdate(t *testing.T) {
 	require.NoError(t, err)
 	defer grpcServer.Stop()
 
-	client, err := client.ReplicaConnect(addr, "local")
+	client, err := client.ReplicaConnect(
+		addr, "local", "target", client.NewReplicaClientMetrics(),
+	)
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -101,7 +103,9 @@ func TestClient_ForwardUpdateRetryUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	defer grpcServer.Stop()
 
-	client, err := client.ReplicaConnect(addr, "local")
+	client, err := client.ReplicaConnect(
+		addr, "local", "target", client.NewReplicaClientMetrics(),
+	)
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/pkg/registry/client/replicaclient_integration_test.go
+++ b/pkg/registry/client/replicaclient_integration_test.go
@@ -1,0 +1,134 @@
+//go:build all || integration
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/registry/client"
+	"github.com/fuddle-io/fuddle/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeReplicaServer struct {
+	Ch            chan *rpc.Member2
+	numUnavilable int
+
+	rpc.UnimplementedReplicaRegistry2Server
+}
+
+func newFakeReplicaServer(numUnavilable int) *fakeReplicaServer {
+	return &fakeReplicaServer{
+		Ch:            make(chan *rpc.Member2, 64),
+		numUnavilable: numUnavilable,
+	}
+}
+
+func (s *fakeReplicaServer) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	if s.numUnavilable > 0 {
+		s.numUnavilable--
+		return nil, status.Error(
+			codes.Unavailable, "Service is currently unavailable",
+		)
+	}
+
+	s.Ch <- req.Member
+	return &rpc.UpdateResponse{}, nil
+}
+
+func (s *fakeReplicaServer) Serve() (*grpc.Server, string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", fmt.Errorf("fake replica server: listen: %w", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	rpc.RegisterReplicaRegistry2Server(grpcServer, s)
+
+	go func() {
+		if err := grpcServer.Serve(ln); err != nil {
+			panic(err)
+		}
+	}()
+
+	return grpcServer, ln.Addr().String(), nil
+}
+
+func TestClient_ForwardUpdate(t *testing.T) {
+	server := newFakeReplicaServer(0)
+	grpcServer, addr, err := server.Serve()
+	require.NoError(t, err)
+	defer grpcServer.Stop()
+
+	client, err := client.ReplicaConnect(addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	member := &rpc.Member2{
+		State:    testutils.RandomMemberState("new-member", ""),
+		Liveness: rpc.Liveness_UP,
+		Version: &rpc.Version2{
+			OwnerId: "foo-123",
+			Timestamp: &rpc.MonotonicTimestamp{
+				Timestamp: time.Now().UnixMilli() + 10000,
+			},
+		},
+	}
+	client.Update(member)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	update, ok := waitWithContext(ctx, server.Ch)
+	assert.True(t, ok, "timeout")
+	assert.True(t, proto.Equal(member, update))
+}
+
+// Tests the replica client retries updates when the server is unavailable.
+func TestClient_ForwardUpdateRetryUnavailable(t *testing.T) {
+	// Configure the server to return UNAVAILABLE the first 4 attempts.
+	server := newFakeReplicaServer(4)
+	grpcServer, addr, err := server.Serve()
+	require.NoError(t, err)
+	defer grpcServer.Stop()
+
+	client, err := client.ReplicaConnect(addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	member := &rpc.Member2{
+		State:    testutils.RandomMemberState("new-member", ""),
+		Liveness: rpc.Liveness_UP,
+		Version: &rpc.Version2{
+			OwnerId: "foo-123",
+			Timestamp: &rpc.MonotonicTimestamp{
+				Timestamp: time.Now().UnixMilli() + 10000,
+			},
+		},
+	}
+	client.Update(member)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	update, ok := waitWithContext(ctx, server.Ch)
+	assert.True(t, ok, "timeout")
+	assert.True(t, proto.Equal(member, update))
+}
+
+func waitWithContext(ctx context.Context, ch chan *rpc.Member2) (*rpc.Member2, bool) {
+	select {
+	case m := <-ch:
+		return m, true
+	case <-ctx.Done():
+		return nil, false
+	}
+}

--- a/pkg/registry/client/replicaclient_integration_test.go
+++ b/pkg/registry/client/replicaclient_integration_test.go
@@ -70,7 +70,7 @@ func TestClient_ForwardUpdate(t *testing.T) {
 	require.NoError(t, err)
 	defer grpcServer.Stop()
 
-	client, err := client.ReplicaConnect(addr)
+	client, err := client.ReplicaConnect(addr, "local")
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -101,7 +101,7 @@ func TestClient_ForwardUpdateRetryUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	defer grpcServer.Stop()
 
-	client, err := client.ReplicaConnect(addr)
+	client, err := client.ReplicaConnect(addr, "local")
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/pkg/registry/registry/registry.go
+++ b/pkg/registry/registry/registry.go
@@ -97,6 +97,13 @@ func NewRegistry(localID string, opts ...Option) *Registry {
 	return reg
 }
 
+func (r *Registry) LocalID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.localID
+}
+
 // MemberState returns the member with the given ID, or false if it is not found.
 func (r *Registry) MemberState(id string) (*rpc.MemberState, bool) {
 	r.mu.Lock()

--- a/pkg/registry/server/replicaserver.go
+++ b/pkg/registry/server/replicaserver.go
@@ -4,14 +4,35 @@ import (
 	"context"
 
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/metrics"
 	"github.com/fuddle-io/fuddle/pkg/registry/registry"
 	"go.uber.org/zap"
 )
 
+type ReplicaServerMetrics struct {
+	ReplicaUpdatesInbound *metrics.Counter
+}
+
+func NewReplicaServerMetrics() *ReplicaServerMetrics {
+	return &ReplicaServerMetrics{
+		ReplicaUpdatesInbound: metrics.NewCounter(
+			"registry",
+			"replica.updates.inbound",
+			[]string{"source"},
+			"Number of inbound updates received from replicas",
+		),
+	}
+}
+
+func (m *ReplicaServerMetrics) Register(collector metrics.Collector) {
+	collector.AddCounter(m.ReplicaUpdatesInbound)
+}
+
 type ReplicaServer struct {
 	registry *registry.Registry
 
-	logger *zap.Logger
+	metrics *ReplicaServerMetrics
+	logger  *zap.Logger
 
 	rpc.UnimplementedReplicaRegistry2Server
 }
@@ -22,13 +43,27 @@ func NewReplicaServer(reg *registry.Registry, opts ...Option) *ReplicaServer {
 		o.apply(options)
 	}
 
+	metrics := NewReplicaServerMetrics()
+	if options.collector != nil {
+		metrics.Register(options.collector)
+	}
+
 	return &ReplicaServer{
 		registry: reg,
+		metrics:  metrics,
 		logger:   options.logger,
 	}
 }
 
+func (s *ReplicaServer) Metrics() *ReplicaServerMetrics {
+	return s.metrics
+}
+
 func (s *ReplicaServer) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	s.metrics.ReplicaUpdatesInbound.Inc(map[string]string{
+		"source": req.SourceNodeId,
+	})
+
 	s.registry.RemoteUpdate(req.Member)
 	return &rpc.UpdateResponse{}, nil
 }

--- a/pkg/registry/server/replicaserver.go
+++ b/pkg/registry/server/replicaserver.go
@@ -4,20 +4,16 @@ import (
 	"context"
 
 	rpc "github.com/fuddle-io/fuddle-rpc/go"
-	"github.com/fuddle-io/fuddle/pkg/metrics"
 	"github.com/fuddle-io/fuddle/pkg/registry/registry"
 	"go.uber.org/zap"
 )
 
-// ReplicaServer services updates to the registry to other Fuddle
-// nodes in the cluster.
 type ReplicaServer struct {
 	registry *registry.Registry
 
-	outboundUpdates *metrics.Counter
-	logger          *zap.Logger
+	logger *zap.Logger
 
-	rpc.UnimplementedReplicaReadRegistryServer
+	rpc.UnimplementedReplicaRegistry2Server
 }
 
 func NewReplicaServer(reg *registry.Registry, opts ...Option) *ReplicaServer {
@@ -26,54 +22,17 @@ func NewReplicaServer(reg *registry.Registry, opts ...Option) *ReplicaServer {
 		o.apply(options)
 	}
 
-	outboundUpdates := metrics.NewCounter(
-		"registry",
-		"updates.replica.outbound",
-		[]string{},
-		"Number of outbound updates to a replica node",
-	)
-	if options.collector != nil {
-		options.collector.AddCounter(outboundUpdates)
-	}
-
 	return &ReplicaServer{
-		registry:        reg,
-		outboundUpdates: outboundUpdates,
-		logger:          options.logger,
+		registry: reg,
+		logger:   options.logger,
 	}
-}
-
-func (s *ReplicaServer) Updates(req *rpc.SubscribeRequest, stream rpc.ReplicaReadRegistry_UpdatesServer) error {
-	logger := s.logger.With(zap.String("rpc", "ReplicaServer.Updates"))
-	logger.Debug("updates stream")
-
-	unsubscribe := s.registry.Subscribe(req, func(update *rpc.Member2) {
-		logger.Debug(
-			"send update",
-			zap.String("id", update.State.Id),
-		)
-
-		s.outboundUpdates.Inc(map[string]string{})
-
-		// Ignore return error, if the client closes the stream the context
-		// will be cancelled.
-		// nolint
-		stream.Send(update)
-	})
-	defer unsubscribe()
-
-	<-stream.Context().Done()
-	logger.Debug("subscribe stream closed")
-
-	return nil
 }
 
 func (s *ReplicaServer) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
-	s.logger.Debug(
-		"replica update",
-		zap.String("id", req.Member.State.Id),
-	)
-
 	s.registry.RemoteUpdate(req.Member)
 	return &rpc.UpdateResponse{}, nil
+}
+
+func (s *ReplicaServer) Sync(ctx context.Context, req *rpc.ReplicaSyncRequest) (*rpc.ReplicaSyncResponse, error) {
+	return &rpc.ReplicaSyncResponse{}, nil
 }

--- a/pkg/registry/server/replicaserver_test.go
+++ b/pkg/registry/server/replicaserver_test.go
@@ -1,0 +1,39 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/fuddle-io/fuddle/pkg/registry/registry"
+	"github.com/fuddle-io/fuddle/pkg/registry/server"
+	"github.com/fuddle-io/fuddle/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestReplicaServer_Update(t *testing.T) {
+	reg := registry.NewRegistry("local")
+	server := server.NewReplicaServer(reg)
+
+	member := &rpc.Member2{
+		State:    testutils.RandomMemberState("new-member", ""),
+		Liveness: rpc.Liveness_UP,
+		Version: &rpc.Version2{
+			OwnerId: "foo-123",
+			Timestamp: &rpc.MonotonicTimestamp{
+				Timestamp: time.Now().UnixMilli() + 10000,
+			},
+		},
+	}
+	_, err := server.Update(context.Background(), &rpc.UpdateRequest{
+		Member: member,
+	})
+	assert.NoError(t, err)
+
+	// Check the registry was updated.
+	m, ok := reg.MemberState("new-member")
+	assert.True(t, ok)
+	assert.True(t, proto.Equal(member.State, m))
+}

--- a/pkg/testutils/member.go
+++ b/pkg/testutils/member.go
@@ -1,0 +1,35 @@
+package testutils
+
+import (
+	"math/rand"
+
+	rpc "github.com/fuddle-io/fuddle-rpc/go"
+	"github.com/google/uuid"
+)
+
+func RandomMemberState(id string, service string) *rpc.MemberState {
+	if id == "" {
+		id = uuid.New().String()
+	}
+	if service == "" {
+		service = uuid.New().String()
+	}
+	return &rpc.MemberState{
+		Id:      id,
+		Service: service,
+		Status:  uuid.New().String(),
+		Locality: &rpc.Locality{
+			Region:           uuid.New().String(),
+			AvailabilityZone: uuid.New().String(),
+		},
+		Started:  rand.Int63(),
+		Revision: uuid.New().String(),
+		Metadata: map[string]string{
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+			uuid.New().String(): uuid.New().String(),
+		},
+	}
+}


### PR DESCRIPTION
# Description
Updates the registry replication server and client to use the v2 service definition.

## Testing
* Already have system tests for replication
* Adds unit tests for the registyr server
* Adds integration tests the the registry client (that tests retries properly)

## Metrics
* `fuddle.replica.updates.inbound`: Number of replica inbound updates with a `source` label
* `fuddle.replica.updates.outbound`: Number of replica outbound updates with labels for `target` and `status`